### PR TITLE
fix: use client:only for Leaderboard to prevent SSR build failure

### DIFF
--- a/src/pages/game/be-the-keeper/leaderboard.astro
+++ b/src/pages/game/be-the-keeper/leaderboard.astro
@@ -14,6 +14,6 @@ import Leaderboard from "@/components/be-the-keeper/Leaderboard";
     </h1>
     <p class="mb-8 text-gray-600">Top 25 keepers at Percy Main CC</p>
 
-    <Leaderboard client:load />
+    <Leaderboard client:only="react" />
   </div>
 </Container>


### PR DESCRIPTION
## Summary
- The Leaderboard component uses `useQuery` from `@tanstack/react-query` but has no `QueryClientProvider` during SSR
- Changing `client:load` to `client:only="react"` skips the server render pass, fixing the build error
- This was breaking Netlify deploy previews

## Test plan
- [x] Local build passes the leaderboard page without error
- [ ] Netlify deploy preview succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)