### PR TITLE
fix: restore action registrations lost in merge

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,8 +1,11 @@
+import { admin } from "./admin";
+import { charges } from "./charges";
 import { checkout } from "./checkout";
 import { createContactSubmission } from "./create-contact-submission";
 import { createEventSubscriber } from "./create-event-subscriber";
 import { gameScore } from "./game-score";
 import { join } from "./join";
+import { addDependents, dependents } from "./junior";
 import { leaderboard } from "./leaderboard";
 import { getMemberDetails, updateMemberDetails } from "./member-details";
 import { membership } from "./membership";
@@ -11,8 +14,12 @@ import { playCricket } from "./play-cricket";
 import { subscriptions } from "./subscriptions";
 
 export const server = {
+  admin,
+  addDependents,
+  charges,
   checkout,
   createContactSubmission,
+  dependents,
   getMemberDetails,
   join,
   payments,


### PR DESCRIPTION
## Summary
- The Google sign-in merge (`a49eb1d`) accidentally dropped `admin`, `charges`, `addDependents`, and `dependents` from `src/actions/index.ts`
- This broke the admin panel, charges/payments view, and junior registration on production

## Test plan
- [ ] Admin panel loads and shows member list
- [ ] Charges tab under profile/payments shows outstanding charges
- [ ] Junior registration form works

🤖 Generated with [Claude Code](https://claude.com/claude-code)