### PR TITLE
fix: show pending status for charges and prevent deletion

### DIFF
--- a/src/actions/admin.tsx
+++ b/src/actions/admin.tsx
@@ -398,6 +398,7 @@ export const admin = {
         })
         .where("id", "=", chargeId)
         .where("paid_at", "is", null)
+        .where("payment_confirmed_at", "is", null)
         .where("deleted_at", "is", null)
         .execute();
 

--- a/src/components/admin/MemberDetailModal.tsx
+++ b/src/components/admin/MemberDetailModal.tsx
@@ -461,12 +461,14 @@ function ChargesSection({ memberId }: { memberId: string }) {
                   <td className="px-3 py-2">
                     {charge.paid_at ? (
                       <StatusPill variant="green">Paid</StatusPill>
+                    ) : charge.payment_confirmed_at ? (
+                      <StatusPill variant="blue">Pending</StatusPill>
                     ) : (
                       <StatusPill variant="yellow">Unpaid</StatusPill>
                     )}
                   </td>
                   <td className="px-3 py-2">
-                    {!charge.paid_at && (
+                    {!charge.paid_at && !charge.payment_confirmed_at && (
                       <>
                         {deleteTarget === charge.id ? (
                           <div className="flex flex-col gap-1">


### PR DESCRIPTION
## Summary
- Admin member detail view now shows three charge statuses: **Paid** (green), **Pending** (blue), **Unpaid** (yellow) — previously pending charges showed as "Unpaid"
- Hide the delete button for charges with a payment in progress (`payment_confirmed_at` set)
- Add backend guard to `deleteCharge` action to reject deletion of pending charges

## Test plan
- [ ] Create a charge for a member, confirm it shows as "Unpaid" with a delete button
- [ ] Initiate payment on a charge so `payment_confirmed_at` is set — confirm it shows as "Pending" with no delete button
- [ ] Confirm paid charges still show as "Paid" with no delete button

🤖 Generated with [Claude Code](https://claude.com/claude-code)