### PR TITLE
feat: URL-driven tab navigation in members area

### DIFF
--- a/src/components/JuniorRegistration.tsx
+++ b/src/components/JuniorRegistration.tsx
@@ -111,8 +111,8 @@ const JuniorRegistrationInner: FC = () => {
             Your junior members have been registered and a charge has been
             created. Head to the payments tab in the members area to pay.
           </p>
-          <a href="/members" className={btnPrimary + " inline-block"}>
-            Go to Members Area
+          <a href="/members?tab=payments" className={btnPrimary + " inline-block"}>
+            Go to Payments
           </a>
         </div>
       </div>

--- a/src/components/MembersPage.tsx
+++ b/src/components/MembersPage.tsx
@@ -2,6 +2,7 @@ import { useSession } from "@/lib/auth/client";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/ui/Tabs";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { navigate } from "astro:transitions/client";
+import { useState } from "react";
 import { ChangePassword } from "./ChangePassword";
 import { Charges } from "./Charges";
 import { MemberDetails, useMemberDetails } from "./MemberDetails";
@@ -11,10 +12,30 @@ import { Payments } from "./Payments";
 import { Subscriptions } from "./Subscriptions";
 import { TwoFactor } from "./TwoFactor";
 
+const TABS = ["membership", "details", "security", "payments"] as const;
+type Tab = (typeof TABS)[number];
+
+function getInitialTab(): Tab {
+  const param = new URLSearchParams(window.location.search).get("tab");
+  return TABS.includes(param as Tab) ? (param as Tab) : "membership";
+}
+
 const queryClient = new QueryClient();
 
 export const MembersPage = () => {
   const session = useSession();
+  const [tab, setTab] = useState<Tab>(getInitialTab);
+
+  const onTabChange = (value: string) => {
+    setTab(value as Tab);
+    const url = new URL(window.location.href);
+    if (value === "membership") {
+      url.searchParams.delete("tab");
+    } else {
+      url.searchParams.set("tab", value);
+    }
+    window.history.replaceState({}, "", url);
+  };
 
   const hasData = !!session?.data;
   if (!session.isPending && !hasData) {
@@ -51,7 +72,7 @@ export const MembersPage = () => {
           </div>
         </div>
         <IncompleteDetailsBanner />
-        <Tabs defaultValue="membership" className="w-full">
+        <Tabs value={tab} onValueChange={onTabChange} className="w-full">
           <TabsList>
             <TabsTrigger value="membership">Membership</TabsTrigger>
             <TabsTrigger value="details">Your Details</TabsTrigger>


### PR DESCRIPTION
## Summary
- Read `?tab=` query param on mount to support deep-linking to specific tabs (e.g. `/members?tab=payments`)
- Update the URL via `history.replaceState` when switching tabs (no page reload)
- Junior registration "done" step now links to `/members?tab=payments` so users land directly on the payments tab

Closes #104

## Test plan
- [ ] Visit `/members` — should default to Membership tab, no `?tab=` in URL
- [ ] Visit `/members?tab=payments` — should open directly on Payments tab
- [ ] Visit `/members?tab=details` — should open on Your Details tab
- [ ] Visit `/members?tab=bogus` — should fall back to Membership tab
- [ ] Click between tabs — URL should update without page reload
- [ ] Complete junior registration flow — "Go to Payments" button should link to `/members?tab=payments`

🤖 Generated with [Claude Code](https://claude.com/claude-code)