### PR TITLE
fix: backfill historical Stripe payments into charge table

### DIFF
--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -1,5 +1,9 @@
 import { useSession } from "@/lib/auth/client";
+import { Alert, AlertDescription } from "@/ui/Alert";
+import { Button } from "@/ui/Button";
+import { useMutation } from "@tanstack/react-query";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { actions } from "astro:actions";
 import { navigate } from "astro:transitions/client";
 import { useState } from "react";
 import { ContactSubmissionsTable } from "./ContactSubmissionsTable";
@@ -9,6 +13,76 @@ import { MemberTable } from "./MemberTable";
 const queryClient = new QueryClient();
 
 type Tab = "members" | "juniors" | "contacts";
+
+function BackfillButton() {
+  const [result, setResult] = useState<{
+    totalMembers: number;
+    totalProcessed: number;
+    totalSkipped: number;
+    errors: string[];
+  } | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: () => actions.admin.backfillStripePayments({}),
+    onSuccess: (res) => {
+      if (res.data) {
+        setResult(res.data);
+      }
+    },
+  });
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            if (
+              window.confirm(
+                "This will import historical Stripe payments into the charge table. This is safe to run multiple times. Continue?",
+              )
+            ) {
+              mutation.mutate();
+            }
+          }}
+          disabled={mutation.isPending}
+        >
+          {mutation.isPending ? "Backfilling..." : "Backfill Stripe Payments"}
+        </Button>
+      </div>
+      {mutation.isError && (
+        <Alert variant="destructive">
+          <AlertDescription>
+            Failed to run backfill. Please try again.
+          </AlertDescription>
+        </Alert>
+      )}
+      {result && (
+        <Alert>
+          <AlertDescription>
+            Backfill complete: {result.totalProcessed} succeeded charges
+            processed across {result.totalMembers} members (
+            {result.totalSkipped} failed/pending charges skipped). Duplicates
+            are automatically excluded.
+            {result.errors.length > 0 && (
+              <details className="mt-2">
+                <summary className="cursor-pointer text-red-600">
+                  {result.errors.length} errors
+                </summary>
+                <ul className="mt-1 list-disc pl-4 text-sm">
+                  {result.errors.map((err, i) => (
+                    <li key={i}>{err}</li>
+                  ))}
+                </ul>
+              </details>
+            )}
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
+  );
+}
 
 export function AdminPanel() {
   const session = useSession();
@@ -33,12 +107,15 @@ export function AdminPanel() {
       <div className="flex flex-col gap-4">
         <div className="flex items-center justify-between">
           <h1>Admin Panel</h1>
-          <a
-            className="text-dark rounded border border-gray-800 px-4 py-2 text-sm hover:bg-gray-200"
-            href="/members"
-          >
-            Back to Members Area
-          </a>
+          <div className="flex items-center gap-4">
+            <BackfillButton />
+            <a
+              className="text-dark rounded border border-gray-800 px-4 py-2 text-sm hover:bg-gray-200"
+              href="/members"
+            >
+              Back to Members Area
+            </a>
+          </div>
         </div>
         <div className="flex border-b border-gray-200">
           <button

--- a/src/lib/db/service/createPaymentCharge.ts
+++ b/src/lib/db/service/createPaymentCharge.ts
@@ -9,7 +9,7 @@ export type ChargeType =
   // TODO: wire up junior_membership once junior membership handler is implemented
   | "junior_membership";
 
-export type ChargeSource = "admin" | "webhook" | "self_service";
+export type ChargeSource = "admin" | "webhook" | "self_service" | "backfill";
 
 interface CreatePaymentChargeParams {
   memberEmail: string;


### PR DESCRIPTION
## Summary
- **Add `backfillStripePayments` admin action** that imports historical Stripe charges into the charge table, fixing the gap left by PR #124 which unified the payment view but didn't backfill pre-existing Stripe-only payments
- **Add "Backfill Stripe Payments" button** to the admin panel so admins can trigger the import with a single click
- **Add `backfill` as a valid charge source** so backfilled records are clearly distinguishable from webhook-created or manually-added charges

## Root cause
PR #124 removed the old `Payments` component (which queried Stripe's API directly at runtime) and replaced it with a unified view reading from the `charge` database table. However, historical Stripe payments (subscription charges from before the webhook handlers were updated) were never recorded in the charge table. This made members' payment history appear empty or incomplete.

## How the backfill works
1. Iterates through all members in the database
2. For each member, looks up their Stripe customer by `stripe_customer_id` (or by email if not set)
3. Paginates through all Stripe charges for that customer
4. For each **succeeded** charge, creates a charge record via `createPaymentCharge`
5. The existing dedup logic (matching on `stripe_payment_intent_id + member_id + type`) prevents duplicate records, making it safe to run multiple times
6. Failed/pending Stripe charges are skipped (these are retry attempts, not useful to show)
7. Also backfills `stripe_customer_id` on member records where it wasn't previously stored

## Test plan
- [ ] Verify the build passes
- [ ] Deploy to preview and confirm the admin panel shows the "Backfill Stripe Payments" button
- [ ] Trigger the backfill on production and verify historical payments appear in member payment history
- [ ] Verify running the backfill a second time doesn't create duplicates
- [ ] Confirm the member's payment history now matches Stripe (for succeeded charges)

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)