### PR TITLE
feat: add junior manager role scoped to specific teams

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -5,6 +5,7 @@ import { createEventSubscriber } from "./create-event-subscriber";
 import { gameScore } from "./game-score";
 import { join } from "./join";
 import { addDependents, dependents } from "./junior";
+import { juniorManager } from "./junior-manager";
 import { leaderboard } from "./leaderboard";
 import { getMemberDetails, updateMemberDetails } from "./member-details";
 import { membership } from "./membership";
@@ -21,6 +22,7 @@ export const server = {
   join,
   addDependents,
   dependents,
+  juniorManager,
   purchase,
   subscribe,
   subscriptions,

--- a/src/actions/junior-manager.ts
+++ b/src/actions/junior-manager.ts
@@ -1,0 +1,218 @@
+import { defineAuthAction } from "@/lib/auth/api";
+import { client } from "@/lib/db/client";
+import { getAgeGroup } from "@/lib/util/ageGroup";
+import { ActionError } from "astro:actions";
+import { z } from "astro:schema";
+
+/**
+ * Returns the user's role from the DB (the session User type from Better Auth
+ * doesn't include the `role` field directly).
+ */
+async function getUserRole(userId: string): Promise<string | null> {
+  const row = await client
+    .selectFrom("user")
+    .where("id", "=", userId)
+    .select("role")
+    .executeTakeFirst();
+  return row?.role ?? null;
+}
+
+/**
+ * Returns the junior_team_ids the user is allowed to view.
+ * Admins get all teams; junior_managers get their assigned teams.
+ */
+async function getAccessibleTeamIds(userId: string): Promise<string[]> {
+  const role = await getUserRole(userId);
+
+  if (role === "admin") {
+    const allTeams = await client
+      .selectFrom("junior_team")
+      .select("id")
+      .execute();
+    return allTeams.map((t) => t.id).filter((id): id is string => id !== null);
+  }
+
+  const assignments = await client
+    .selectFrom("junior_team_manager")
+    .where("user_id", "=", userId)
+    .select("junior_team_id")
+    .execute();
+
+  return assignments.map((a) => a.junior_team_id);
+}
+
+export const juniorManager = {
+  /** List the teams assigned to the current user (or all teams for admins). */
+  listMyTeams: defineAuthAction({
+    roles: ["junior_manager", "admin"],
+    handler: async (_, { user }) => {
+      const accessibleIds = await getAccessibleTeamIds(user.id);
+
+      if (accessibleIds.length === 0) {
+        return [];
+      }
+
+      const teams = await client
+        .selectFrom("junior_team")
+        .where("id", "in", accessibleIds)
+        .selectAll()
+        .orderBy("age_group", "asc")
+        .orderBy("sex", "asc")
+        .execute();
+
+      return teams;
+    },
+  }),
+
+  /** List players (dependents) for a specific team. */
+  listPlayers: defineAuthAction({
+    roles: ["junior_manager", "admin"],
+    input: z.object({
+      teamId: z.string(),
+    }),
+    handler: async ({ teamId }, { user }) => {
+      // Verify the user has access to this team
+      const accessibleIds = await getAccessibleTeamIds(user.id);
+      if (!accessibleIds.includes(teamId)) {
+        throw new ActionError({
+          code: "UNAUTHORIZED",
+          message: "You do not have access to this team.",
+        });
+      }
+
+      // Look up the team to get age_group and sex
+      const team = await client
+        .selectFrom("junior_team")
+        .where("id", "=", teamId)
+        .selectAll()
+        .executeTakeFirst();
+
+      if (!team) {
+        throw new ActionError({
+          code: "NOT_FOUND",
+          message: "Team not found.",
+        });
+      }
+
+      // Get all dependents and filter by computed age group + sex match
+      const rows = await client
+        .selectFrom("dependent")
+        .innerJoin("member", "member.id", "dependent.member_id")
+        .where("dependent.sex", "=", team.sex)
+        .select([
+          "dependent.id",
+          "dependent.name",
+          "dependent.sex",
+          "dependent.dob",
+          "dependent.created_at as registeredAt",
+          "member.name as parentName",
+          "member.email as parentEmail",
+          "member.telephone as parentTelephone",
+          "member.address as parentAddress",
+          "member.postcode as parentPostcode",
+          "member.emergency_contact_name as emergencyContactName",
+          "member.emergency_contact_telephone as emergencyContactTelephone",
+        ])
+        .orderBy("dependent.name", "asc")
+        .execute();
+
+      // Filter to only dependents whose computed age group matches the team's
+      const players = rows.filter((row) => {
+        const ageGroup = getAgeGroup(row.dob);
+        return ageGroup === team.age_group;
+      });
+
+      return players.map((row) => ({
+        id: row.id,
+        name: row.name,
+        sex: row.sex,
+        dob: row.dob,
+        registeredAt: row.registeredAt,
+        parentName: row.parentName,
+        parentEmail: row.parentEmail,
+        parentTelephone: row.parentTelephone,
+        parentAddress: row.parentAddress,
+        parentPostcode: row.parentPostcode,
+        emergencyContactName: row.emergencyContactName,
+        emergencyContactTelephone: row.emergencyContactTelephone,
+      }));
+    },
+  }),
+
+  /** Get full details for a single player (dependent). Only accessible if the player is in one of the manager's teams. */
+  getPlayerDetail: defineAuthAction({
+    roles: ["junior_manager", "admin"],
+    input: z.object({
+      dependentId: z.string(),
+    }),
+    handler: async ({ dependentId }, { user }) => {
+      const accessibleIds = await getAccessibleTeamIds(user.id);
+
+      const row = await client
+        .selectFrom("dependent")
+        .innerJoin("member", "member.id", "dependent.member_id")
+        .where("dependent.id", "=", dependentId)
+        .select([
+          "dependent.id",
+          "dependent.name",
+          "dependent.sex",
+          "dependent.dob",
+          "dependent.created_at as registeredAt",
+          "member.name as parentName",
+          "member.email as parentEmail",
+          "member.telephone as parentTelephone",
+          "member.address as parentAddress",
+          "member.postcode as parentPostcode",
+          "member.emergency_contact_name as emergencyContactName",
+          "member.emergency_contact_telephone as emergencyContactTelephone",
+        ])
+        .executeTakeFirst();
+
+      if (!row) {
+        throw new ActionError({
+          code: "NOT_FOUND",
+          message: "Player not found.",
+        });
+      }
+
+      // Check team access: compute the player's team and verify it's accessible
+      const ageGroup = getAgeGroup(row.dob);
+      if (!ageGroup) {
+        throw new ActionError({
+          code: "NOT_FOUND",
+          message: "Player is not in a junior age group.",
+        });
+      }
+
+      // Find the team that matches this player's age group + sex
+      const matchingTeam = await client
+        .selectFrom("junior_team")
+        .where("age_group", "=", ageGroup)
+        .where("sex", "=", row.sex)
+        .select("id")
+        .executeTakeFirst();
+
+      if (!matchingTeam?.id || !accessibleIds.includes(matchingTeam.id)) {
+        throw new ActionError({
+          code: "UNAUTHORIZED",
+          message: "You do not have access to this player's team.",
+        });
+      }
+
+      return {
+        id: row.id,
+        name: row.name,
+        sex: row.sex,
+        dob: row.dob,
+        registeredAt: row.registeredAt,
+        parentName: row.parentName,
+        parentEmail: row.parentEmail,
+        parentTelephone: row.parentTelephone,
+        parentAddress: row.parentAddress,
+        parentPostcode: row.parentPostcode,
+        emergencyContactName: row.emergencyContactName,
+        emergencyContactTelephone: row.emergencyContactTelephone,
+      };
+    },
+  }),
+};

--- a/src/components/MembersPage.tsx
+++ b/src/components/MembersPage.tsx
@@ -62,6 +62,16 @@ export const MembersPage = () => {
               </a>
             ) : null}
 
+            {(session.data.user.role === "junior_manager" ||
+              session.data.user.role === "admin") && (
+              <a
+                className="text-dark justify-self-start rounded border-1 border-gray-800 px-4 py-2 text-sm hover:bg-gray-200"
+                href="/junior-manager"
+              >
+                Junior Teams
+              </a>
+            )}
+
             <a
               className="text-dark justify-self-start rounded border-1 border-gray-800 px-4 py-2 text-sm hover:bg-gray-200"
               href="/auth/logout"

--- a/src/components/admin/MemberDetailModal.tsx
+++ b/src/components/admin/MemberDetailModal.tsx
@@ -1,7 +1,8 @@
+import { Button } from "@/components/ui/Button";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { actions } from "astro:actions";
 import { formatDate } from "date-fns";
-import { type FormEvent, useState } from "react";
+import { type FormEvent, useEffect, useState } from "react";
 import { StatusPill, getMembershipStatus } from "./StatusPill";
 
 const currencyFormatter = new Intl.NumberFormat("en-GB", {
@@ -90,10 +91,16 @@ export function MemberDetailModal({
                 <dd>
                   <StatusPill
                     variant={
-                      detail.user.role === "admin" ? "blue" : "gray"
+                      detail.user.role === "admin"
+                        ? "blue"
+                        : detail.user.role === "junior_manager"
+                          ? "green"
+                          : "gray"
                     }
                   >
-                    {detail.user.role ?? "user"}
+                    {detail.user.role === "junior_manager"
+                      ? "Junior Manager"
+                      : (detail.user.role ?? "user")}
                   </StatusPill>
                 </dd>
                 <dt className="font-medium text-gray-500">Email Verified</dt>
@@ -224,6 +231,9 @@ export function MemberDetailModal({
               )}
             </section>
 
+            {/* Junior Manager */}
+            <JuniorManagerSection userId={userId} currentRole={detail.user.role} />
+
             {/* Payments (charges) */}
             {detail.member && (
               <ChargesSection memberId={detail.member.id} />
@@ -232,6 +242,181 @@ export function MemberDetailModal({
         )}
       </div>
     </div>
+  );
+}
+
+function JuniorManagerSection({
+  userId,
+  currentRole,
+}: {
+  userId: string;
+  currentRole: string | null;
+}) {
+  const queryClient = useQueryClient();
+  const [selectedTeams, setSelectedTeams] = useState<Set<string>>(new Set());
+  const [hasInitialised, setHasInitialised] = useState(false);
+
+  const teamsQuery = useQuery({
+    queryKey: ["admin", "listJuniorTeams"],
+    queryFn: () => actions.admin.listJuniorTeams(),
+  });
+
+  const assignedQuery = useQuery({
+    queryKey: ["admin", "juniorManagerTeams", userId],
+    queryFn: () => actions.admin.getJuniorManagerTeams({ userId }),
+  });
+
+  // Initialise selection from current assignments
+  useEffect(() => {
+    if (assignedQuery.data?.data && !hasInitialised) {
+      setSelectedTeams(new Set(assignedQuery.data.data));
+      setHasInitialised(true);
+    }
+  }, [assignedQuery.data, hasInitialised]);
+
+  const mutation = useMutation({
+    mutationFn: (teamIds: string[]) =>
+      actions.admin.setJuniorManager({ userId, teamIds }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["admin", "userDetail", userId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["admin", "juniorManagerTeams", userId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["admin", "listUsers"],
+      });
+    },
+  });
+
+  // Don't show for admins (they have full access already)
+  if (currentRole === "admin") {
+    return (
+      <section>
+        <h3 className="mb-2 text-lg font-medium">Junior Manager</h3>
+        <p className="text-sm text-gray-500">
+          Admins have full access to all teams. Demote to User first to assign
+          specific teams.
+        </p>
+      </section>
+    );
+  }
+
+  const allTeams = teamsQuery.data?.data ?? [];
+  const assignedTeamIds = assignedQuery.data?.data ?? [];
+
+  const toggleTeam = (teamId: string) => {
+    setSelectedTeams((prev) => {
+      const next = new Set(prev);
+      if (next.has(teamId)) {
+        next.delete(teamId);
+      } else {
+        next.add(teamId);
+      }
+      return next;
+    });
+  };
+
+  const hasChanges = (() => {
+    const current = new Set(assignedTeamIds);
+    if (current.size !== selectedTeams.size) return true;
+    for (const id of selectedTeams) {
+      if (!current.has(id)) return true;
+    }
+    return false;
+  })();
+
+  const handleSave = () => {
+    mutation.mutate(Array.from(selectedTeams));
+  };
+
+  const handleRemoveAll = () => {
+    setSelectedTeams(new Set());
+    mutation.mutate([]);
+  };
+
+  const isJuniorManager = currentRole === "junior_manager";
+
+  return (
+    <section>
+      <h3 className="mb-2 text-lg font-medium">Junior Manager</h3>
+
+      {teamsQuery.isLoading || assignedQuery.isLoading ? (
+        <p className="text-sm text-gray-500">Loading teams...</p>
+      ) : teamsQuery.isError || assignedQuery.isError ? (
+        <p className="text-sm text-red-600">Failed to load teams.</p>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {isJuniorManager && (
+            <p className="text-sm text-gray-600">
+              This user is a junior manager. Select the teams they can access.
+            </p>
+          )}
+
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+            {allTeams.map((team) => {
+              const teamId = team.id ?? "";
+              const isSelected = selectedTeams.has(teamId);
+              return (
+                <label
+                  key={teamId}
+                  className={`flex cursor-pointer items-center gap-2 rounded border px-3 py-2 text-sm transition-colors ${
+                    isSelected
+                      ? "border-blue-500 bg-blue-50 text-blue-800"
+                      : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={isSelected}
+                    onChange={() => toggleTeam(teamId)}
+                    className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  />
+                  {team.name}
+                </label>
+              );
+            })}
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              disabled={!hasChanges || mutation.isPending}
+              onClick={handleSave}
+            >
+              {mutation.isPending
+                ? "Saving..."
+                : selectedTeams.size > 0
+                  ? "Save Team Assignments"
+                  : "Remove Junior Manager Role"}
+            </Button>
+            {isJuniorManager && (
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={mutation.isPending}
+                onClick={handleRemoveAll}
+              >
+                Remove All Teams
+              </Button>
+            )}
+          </div>
+
+          {mutation.isError && (
+            <p className="text-sm text-red-600">
+              Failed to update team assignments.
+            </p>
+          )}
+
+          {mutation.isSuccess && (
+            <p className="text-sm text-green-600">
+              Team assignments updated successfully.
+            </p>
+          )}
+        </div>
+      )}
+    </section>
   );
 }
 

--- a/src/components/junior-manager/JuniorManagerPanel.tsx
+++ b/src/components/junior-manager/JuniorManagerPanel.tsx
@@ -1,0 +1,285 @@
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/Table";
+import { useSession } from "@/lib/auth/client";
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
+import { actions } from "astro:actions";
+import { navigate } from "astro:transitions/client";
+import { formatDate } from "date-fns";
+import { useState } from "react";
+
+const queryClient = new QueryClient();
+
+export function JuniorManagerPanel() {
+  const session = useSession();
+
+  if (session.isPending) {
+    return <p className="text-gray-500">Loading...</p>;
+  }
+
+  if (!session.data) {
+    void navigate("/auth/login");
+    return null;
+  }
+
+  const role = session.data.user.role;
+  if (role !== "junior_manager" && role !== "admin") {
+    void navigate("/members");
+    return null;
+  }
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center justify-between">
+          <h1>Junior Teams</h1>
+          <div className="flex gap-2">
+            {role === "admin" && (
+              <a
+                className="text-dark rounded border border-gray-800 px-4 py-2 text-sm hover:bg-gray-200"
+                href="/admin"
+              >
+                Admin Panel
+              </a>
+            )}
+            <a
+              className="text-dark rounded border border-gray-800 px-4 py-2 text-sm hover:bg-gray-200"
+              href="/members"
+            >
+              Members Area
+            </a>
+          </div>
+        </div>
+        <TeamsDashboard />
+      </div>
+    </QueryClientProvider>
+  );
+}
+
+function TeamsDashboard() {
+  const teamsQuery = useQuery({
+    queryKey: ["juniorManager", "myTeams"],
+    queryFn: () => actions.juniorManager.listMyTeams(),
+  });
+
+  if (teamsQuery.isLoading) {
+    return <p className="text-gray-500">Loading teams...</p>;
+  }
+
+  if (teamsQuery.isError) {
+    return <p className="text-red-600">Failed to load teams.</p>;
+  }
+
+  const teams = teamsQuery.data?.data ?? [];
+
+  if (teams.length === 0) {
+    return (
+      <p className="text-gray-500">
+        You have not been assigned to any teams. Contact an admin to get access.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-gray-500">
+        You have access to {teams.length} team{teams.length !== 1 ? "s" : ""}.
+        Select a team to view players.
+      </p>
+      {teams.map((team) => (
+        <TeamCard key={team.id} teamId={team.id ?? ""} teamName={team.name} />
+      ))}
+    </div>
+  );
+}
+
+interface Player {
+  id: string;
+  name: string;
+  sex: string;
+  dob: string;
+  registeredAt: string;
+  parentName: string;
+  parentEmail: string;
+  parentTelephone: string;
+  parentAddress: string;
+  parentPostcode: string;
+  emergencyContactName: string;
+  emergencyContactTelephone: string;
+}
+
+function TeamCard({
+  teamId,
+  teamName,
+}: {
+  teamId: string;
+  teamName: string;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  const playersQuery = useQuery({
+    queryKey: ["juniorManager", "players", teamId],
+    queryFn: () => actions.juniorManager.listPlayers({ teamId }),
+    enabled: expanded,
+  });
+
+  const players: Player[] = playersQuery.data?.data ?? [];
+
+  return (
+    <Card>
+      <CardHeader
+        className="cursor-pointer"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2">
+            {teamName}
+            {playersQuery.data && (
+              <Badge variant="secondary">{players.length}</Badge>
+            )}
+          </CardTitle>
+          <span className="text-sm text-gray-400">
+            {expanded ? "Collapse" : "Expand"}
+          </span>
+        </div>
+      </CardHeader>
+      {expanded && (
+        <CardContent>
+          {playersQuery.isLoading && (
+            <p className="text-sm text-gray-500">Loading players...</p>
+          )}
+          {playersQuery.isError && (
+            <p className="text-sm text-red-600">Failed to load players.</p>
+          )}
+          {playersQuery.isSuccess && players.length === 0 && (
+            <p className="text-sm text-gray-500">
+              No players registered in this team.
+            </p>
+          )}
+          {players.length > 0 && <PlayersTable players={players} />}
+        </CardContent>
+      )}
+    </Card>
+  );
+}
+
+function PlayersTable({ players }: { players: Player[] }) {
+  const [expandedPlayer, setExpandedPlayer] = useState<string | null>(null);
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead>DOB</TableHead>
+          <TableHead>Parent</TableHead>
+          <TableHead>Contact</TableHead>
+          <TableHead>Details</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {players.map((player) => (
+          <>
+            <TableRow key={player.id}>
+              <TableCell className="font-medium">{player.name}</TableCell>
+              <TableCell>{formatDate(player.dob, "dd/MM/yyyy")}</TableCell>
+              <TableCell>{player.parentName}</TableCell>
+              <TableCell>
+                <div className="flex flex-col gap-0.5 text-xs">
+                  <a
+                    href={`mailto:${player.parentEmail}`}
+                    className="text-blue-600 hover:underline"
+                  >
+                    {player.parentEmail}
+                  </a>
+                  <span>{player.parentTelephone}</span>
+                </div>
+              </TableCell>
+              <TableCell>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() =>
+                    setExpandedPlayer(
+                      expandedPlayer === player.id ? null : player.id,
+                    )
+                  }
+                >
+                  {expandedPlayer === player.id ? "Hide" : "View"}
+                </Button>
+              </TableCell>
+            </TableRow>
+            {expandedPlayer === player.id && (
+              <TableRow key={`${player.id}-detail`}>
+                <TableCell colSpan={5}>
+                  <div className="rounded bg-gray-50 p-4">
+                    <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+                      <dt className="font-medium text-gray-500">
+                        Player Name
+                      </dt>
+                      <dd>{player.name}</dd>
+                      <dt className="font-medium text-gray-500">
+                        Date of Birth
+                      </dt>
+                      <dd>{formatDate(player.dob, "dd/MM/yyyy")}</dd>
+                      <dt className="font-medium text-gray-500">Sex</dt>
+                      <dd className="capitalize">{player.sex}</dd>
+                      <dt className="font-medium text-gray-500">
+                        Registered
+                      </dt>
+                      <dd>
+                        {formatDate(player.registeredAt, "dd/MM/yyyy")}
+                      </dd>
+                      <dt className="mt-3 font-medium text-gray-500">
+                        Parent / Guardian
+                      </dt>
+                      <dd className="mt-3">{player.parentName}</dd>
+                      <dt className="font-medium text-gray-500">Email</dt>
+                      <dd>
+                        <a
+                          href={`mailto:${player.parentEmail}`}
+                          className="text-blue-600 hover:underline"
+                        >
+                          {player.parentEmail}
+                        </a>
+                      </dd>
+                      <dt className="font-medium text-gray-500">
+                        Telephone
+                      </dt>
+                      <dd>{player.parentTelephone}</dd>
+                      <dt className="font-medium text-gray-500">Address</dt>
+                      <dd>
+                        {player.parentAddress}
+                        {player.parentPostcode && (
+                          <>, {player.parentPostcode}</>
+                        )}
+                      </dd>
+                      <dt className="mt-3 font-medium text-gray-500">
+                        Emergency Contact
+                      </dt>
+                      <dd className="mt-3">
+                        {player.emergencyContactName}
+                      </dd>
+                      <dt className="font-medium text-gray-500">
+                        Emergency Phone
+                      </dt>
+                      <dd>{player.emergencyContactTelephone}</dd>
+                    </dl>
+                  </div>
+                </TableCell>
+              </TableRow>
+            )}
+          </>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/lib/db/__generated__/db.ts
+++ b/src/lib/db/__generated__/db.ts
@@ -83,6 +83,19 @@ export interface GameScore {
   user_id: string;
 }
 
+export interface JuniorTeam {
+  age_group: string;
+  created_at: Generated<string>;
+  id: string | null;
+  name: string;
+  sex: string;
+}
+
+export interface JuniorTeamManager {
+  junior_team_id: string;
+  user_id: string;
+}
+
 export interface Member {
   address: string;
   dob: string;
@@ -170,6 +183,8 @@ export interface DB {
   dependent: Dependent;
   event_subscriber: EventSubscriber;
   game_score: GameScore;
+  junior_team: JuniorTeam;
+  junior_team_manager: JuniorTeamManager;
   member: Member;
   membership: Membership;
   passkey: Passkey;

--- a/src/lib/db/migrations/2026-02-26T00:00:00.000Z.ts
+++ b/src/lib/db/migrations/2026-02-26T00:00:00.000Z.ts
@@ -1,0 +1,44 @@
+import { Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("junior_team")
+    .addColumn("id", "text", (col) => col.primaryKey())
+    .addColumn("name", "text", (col) => col.notNull())
+    .addColumn("age_group", "text", (col) => col.notNull())
+    .addColumn("sex", "text", (col) => col.notNull())
+    .addColumn("created_at", "text", (col) =>
+      col.notNull().defaultTo(sql`CURRENT_TIMESTAMP`),
+    )
+    .execute();
+
+  await db.schema
+    .createTable("junior_team_manager")
+    .addColumn("user_id", "text", (col) => col.notNull().references("user.id"))
+    .addColumn("junior_team_id", "text", (col) =>
+      col.notNull().references("junior_team.id"),
+    )
+    .addPrimaryKeyConstraint("junior_team_manager_pk", [
+      "user_id",
+      "junior_team_id",
+    ])
+    .execute();
+
+  // Seed the junior_team table with all age group / sex combinations
+  const teams = [
+    { id: "u11-boys", name: "U11 Boys", age_group: "U11", sex: "male" },
+    { id: "u11-girls", name: "U11 Girls", age_group: "U11", sex: "female" },
+    { id: "u13-boys", name: "U13 Boys", age_group: "U13", sex: "male" },
+    { id: "u13-girls", name: "U13 Girls", age_group: "U13", sex: "female" },
+    { id: "u15-boys", name: "U15 Boys", age_group: "U15", sex: "male" },
+    { id: "u15-girls", name: "U15 Girls", age_group: "U15", sex: "female" },
+    { id: "u19-boys", name: "U19 Boys", age_group: "U19", sex: "male" },
+    { id: "u19-girls", name: "U19 Girls", age_group: "U19", sex: "female" },
+  ];
+
+  for (const team of teams) {
+    await sql`INSERT INTO junior_team (id, name, age_group, sex) VALUES (${team.id}, ${team.name}, ${team.age_group}, ${team.sex})`.execute(
+      db,
+    );
+  }
+}

--- a/src/pages/junior-manager.astro
+++ b/src/pages/junior-manager.astro
@@ -1,0 +1,8 @@
+---
+import { JuniorManagerPanel } from "@/components/junior-manager/JuniorManagerPanel";
+import Container from "@/layouts/Container.astro";
+---
+
+<Container title="Junior Teams">
+  <JuniorManagerPanel client:only="react" />
+</Container>


### PR DESCRIPTION
## Summary

Adds a new `junior_manager` role that grants team-scoped read access to junior player details and parent contact information. This is an admin-only assignment (not self-service).

- **DB**: New `junior_team` table (8 pre-seeded teams: U11-U19 x Boys/Girls) and `junior_team_manager` junction table
- **Admin UI**: Team assignment section in MemberDetailModal with multi-select checkboxes — selecting teams auto-assigns the `junior_manager` role; removing all teams reverts to `user`
- **Junior Manager dashboard**: New `/junior-manager` page showing assigned teams with expandable player cards including parent address, phone, email, and emergency contacts
- **Navigation**: "Junior Teams" link shown in Members Area for `junior_manager` and `admin` roles

## Test plan

- [ ] Admin can assign teams to a user via MemberDetailModal — user role changes to `junior_manager`
- [ ] Admin can remove all teams — user role reverts to `user`
- [ ] Admin cannot assign teams to another admin (must demote first)
- [ ] Junior manager sees only their assigned teams on `/junior-manager`
- [ ] Junior manager can expand a team to view players with full parent details
- [ ] Junior manager cannot access players from teams they are not assigned to
- [ ] Admin can access all teams on `/junior-manager`
- [ ] Regular users are redirected away from `/junior-manager`
- [ ] "Junior Teams" link appears in Members Area for junior_manager and admin roles only

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)