### PR TITLE
feat: admin charges view with filters and aggregation

### DIFF
--- a/emails/PaymentReminder.tsx
+++ b/emails/PaymentReminder.tsx
@@ -1,0 +1,101 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Hr,
+  Html,
+  Img,
+  Preview,
+  Section,
+  Text,
+} from "@react-email/components";
+import type { FC } from "react";
+import { email } from "./email";
+import * as styles from "./styles";
+
+interface Props {
+  imageBaseUrl: string;
+  name: string;
+  description: string;
+  amount: string;
+  chargeDate: string;
+  loginUrl: string;
+}
+
+const Component: FC<Props> = ({
+  name,
+  imageBaseUrl,
+  description,
+  amount,
+  chargeDate,
+  loginUrl,
+}) => (
+  <Html>
+    <Head />
+    <Preview>
+      Percy Main Community Sports Club - Payment Reminder: {description}
+    </Preview>
+    <Body style={styles.main}>
+      <Container style={styles.container}>
+        <Img
+          src={`${imageBaseUrl}/club_logo.png`}
+          width="100"
+          height="100"
+          alt="Percy Main Club Logo"
+          style={styles.logo}
+        />
+        <Text style={styles.paragraph}>Hi {name},</Text>
+        <Text style={styles.paragraph}>
+          This is a friendly reminder that you have an outstanding payment on
+          your account:
+        </Text>
+        <ul>
+          <li>
+            <em>Description: </em>
+            {description}
+          </li>
+          <li>
+            <em>Amount: </em>
+            {amount}
+          </li>
+          <li>
+            <em>Date: </em>
+            {chargeDate}
+          </li>
+        </ul>
+        <Text style={styles.paragraph}>
+          Please log in to the members area to complete your payment at your
+          earliest convenience.
+        </Text>
+        <Section style={styles.btnContainer}>
+          <Button style={styles.button} href={loginUrl}>
+            Log In to Pay
+          </Button>
+        </Section>
+        <Text style={styles.paragraph}>
+          Best,
+          <br />
+          The Trustees
+        </Text>
+        <Hr style={styles.hr} />
+        <Text style={styles.footer}>
+          Percy Main Cricket Club, St. Johns Terrace, North Shields, NE29 6HS
+        </Text>
+      </Container>
+    </Body>
+  </Html>
+);
+
+export const PaymentReminder = email<Props>("Payment Reminder", {
+  preview: {
+    imageBaseUrl: "http://localhost:4321/images",
+    name: "Alex",
+    description: "Match fee - Senior XI vs Benwell Hill",
+    amount: "\u00a35.00",
+    chargeDate: "25/02/2026",
+    loginUrl: "http://localhost:4321/auth/login",
+  },
+})(Component);
+
+export default PaymentReminder.component;

--- a/src/actions/admin.tsx
+++ b/src/actions/admin.tsx
@@ -8,8 +8,12 @@ import { ActionError } from "astro:actions";
 import { BASE_URL } from "astro:env/client";
 import { z } from "astro:schema";
 import { randomUUID } from "crypto";
-import { formatDate } from "date-fns";
+import { formatDate, subHours } from "date-fns";
+import { sql } from "kysely";
 import { ChargeNotification } from "~/emails/ChargeNotification";
+import { PaymentReminder } from "~/emails/PaymentReminder";
+
+const ABANDONED_THRESHOLD_HOURS = 1;
 
 export const admin = {
   listUsers: defineAuthAction({
@@ -448,4 +452,257 @@ export const admin = {
       }));
     },
   }),
+
+  listAllCharges: defineAuthAction({
+    roles: ["admin"],
+    input: z.object({
+      page: z.number().int().min(1),
+      pageSize: z.number().int().min(1).max(100),
+      status: z.enum(["all", "unpaid", "pending", "paid", "abandoned"]).default("all"),
+      showDeleted: z.boolean().default(false),
+      dateFrom: z.string().optional(),
+      dateTo: z.string().optional(),
+      search: z.string().optional(),
+    }),
+    handler: async ({ page, pageSize, status, showDeleted, dateFrom, dateTo, search }) => {
+      const abandonedCutoff = subHours(new Date(), ABANDONED_THRESHOLD_HOURS).toISOString();
+
+      function applyFilters(
+        baseQuery: ReturnType<typeof client.selectFrom<"charge">>,
+      ) {
+        let q = baseQuery
+          .innerJoin("member", "member.id", "charge.member_id");
+
+        // Deleted filter
+        if (!showDeleted) {
+          q = q.where("charge.deleted_at", "is", null);
+        }
+
+        // Status filter
+        if (status === "paid") {
+          q = q.where("charge.paid_at", "is not", null);
+        } else if (status === "pending") {
+          q = q
+            .where("charge.payment_confirmed_at", "is not", null)
+            .where("charge.paid_at", "is", null)
+            .where("charge.deleted_at", "is", null);
+        } else if (status === "unpaid") {
+          q = q
+            .where("charge.paid_at", "is", null)
+            .where("charge.payment_confirmed_at", "is", null)
+            .where("charge.deleted_at", "is", null)
+            .where((eb) =>
+              eb.or([
+                eb("charge.stripe_payment_intent_id", "is", null),
+                eb("charge.created_at", ">=", abandonedCutoff),
+              ]),
+            );
+        } else if (status === "abandoned") {
+          q = q
+            .where("charge.stripe_payment_intent_id", "is not", null)
+            .where("charge.paid_at", "is", null)
+            .where("charge.payment_confirmed_at", "is", null)
+            .where("charge.deleted_at", "is", null)
+            .where("charge.created_at", "<", abandonedCutoff);
+        }
+
+        // Date range filter
+        if (dateFrom) {
+          q = q.where("charge.charge_date", ">=", dateFrom);
+        }
+        if (dateTo) {
+          q = q.where("charge.charge_date", "<=", dateTo);
+        }
+
+        // Search filter
+        if (search && search.trim().length > 0) {
+          const term = `%${search.trim()}%`;
+          q = q.where((eb) =>
+            eb.or([
+              eb("member.name", "like", term),
+              eb("member.email", "like", term),
+              eb("charge.description", "like", term),
+            ]),
+          );
+        }
+
+        return q;
+      }
+
+      const countQuery = applyFilters(client.selectFrom("charge"));
+      const countResult = await countQuery
+        .select((eb) => eb.fn.countAll().as("total"))
+        .executeTakeFirstOrThrow();
+
+      const total = Number(countResult.total);
+      const offset = (page - 1) * pageSize;
+
+      const dataQuery = applyFilters(client.selectFrom("charge"));
+      const charges = await dataQuery
+        .select([
+          "charge.id",
+          "charge.member_id",
+          "charge.description",
+          "charge.amount_pence",
+          "charge.charge_date",
+          "charge.created_at",
+          "charge.paid_at",
+          "charge.payment_confirmed_at",
+          "charge.stripe_payment_intent_id",
+          "charge.type",
+          "charge.source",
+          "charge.deleted_at",
+          "charge.deleted_reason",
+          "member.name as memberName",
+          "member.email as memberEmail",
+        ])
+        .orderBy("charge.charge_date", "desc")
+        .limit(pageSize)
+        .offset(offset)
+        .execute();
+
+      return {
+        charges: charges.map((c) => ({
+          id: c.id,
+          memberId: c.member_id,
+          description: c.description,
+          amountPence: c.amount_pence,
+          chargeDate: c.charge_date,
+          createdAt: c.created_at,
+          paidAt: c.paid_at,
+          paymentConfirmedAt: c.payment_confirmed_at,
+          stripePaymentIntentId: c.stripe_payment_intent_id,
+          type: c.type,
+          source: c.source,
+          deletedAt: c.deleted_at,
+          deletedReason: c.deleted_reason,
+          memberName: c.memberName,
+          memberEmail: c.memberEmail,
+          status: getChargeStatus(c.paid_at, c.payment_confirmed_at, c.deleted_at, c.stripe_payment_intent_id, abandonedCutoff, c.created_at),
+        })),
+        total,
+        page,
+        pageSize,
+      };
+    },
+  }),
+
+  getChargeAggregates: defineAuthAction({
+    roles: ["admin"],
+    input: z.object({
+      dateFrom: z.string().optional(),
+      dateTo: z.string().optional(),
+    }),
+    handler: async ({ dateFrom, dateTo }) => {
+      const abandonedCutoff = subHours(new Date(), ABANDONED_THRESHOLD_HOURS).toISOString();
+
+      let baseQuery = client
+        .selectFrom("charge")
+        .innerJoin("member", "member.id", "charge.member_id");
+
+      if (dateFrom) {
+        baseQuery = baseQuery.where("charge.charge_date", ">=", dateFrom);
+      }
+      if (dateTo) {
+        baseQuery = baseQuery.where("charge.charge_date", "<=", dateTo);
+      }
+
+      const result = await baseQuery
+        .select([
+          sql<number>`COALESCE(SUM(CASE WHEN charge.deleted_at IS NULL THEN charge.amount_pence ELSE 0 END), 0)`.as("totalCharged"),
+          sql<number>`COALESCE(SUM(CASE WHEN charge.paid_at IS NOT NULL THEN charge.amount_pence ELSE 0 END), 0)`.as("totalPaid"),
+          sql<number>`COALESCE(SUM(CASE WHEN charge.paid_at IS NULL AND charge.deleted_at IS NULL THEN charge.amount_pence ELSE 0 END), 0)`.as("totalOutstanding"),
+          sql<number>`COALESCE(SUM(CASE WHEN charge.stripe_payment_intent_id IS NOT NULL AND charge.paid_at IS NULL AND charge.payment_confirmed_at IS NULL AND charge.deleted_at IS NULL AND charge.created_at < ${abandonedCutoff} THEN charge.amount_pence ELSE 0 END), 0)`.as("totalAbandoned"),
+          sql<number>`COALESCE(SUM(CASE WHEN charge.deleted_at IS NOT NULL THEN charge.amount_pence ELSE 0 END), 0)`.as("totalDeleted"),
+          sql<number>`COUNT(CASE WHEN charge.paid_at IS NOT NULL THEN 1 END)`.as("countPaid"),
+          sql<number>`COUNT(CASE WHEN charge.paid_at IS NULL AND charge.payment_confirmed_at IS NULL AND charge.deleted_at IS NULL AND (charge.stripe_payment_intent_id IS NULL OR charge.created_at >= ${abandonedCutoff}) THEN 1 END)`.as("countUnpaid"),
+          sql<number>`COUNT(CASE WHEN charge.payment_confirmed_at IS NOT NULL AND charge.paid_at IS NULL AND charge.deleted_at IS NULL THEN 1 END)`.as("countPending"),
+          sql<number>`COUNT(CASE WHEN charge.stripe_payment_intent_id IS NOT NULL AND charge.paid_at IS NULL AND charge.payment_confirmed_at IS NULL AND charge.deleted_at IS NULL AND charge.created_at < ${abandonedCutoff} THEN 1 END)`.as("countAbandoned"),
+          sql<number>`COUNT(CASE WHEN charge.deleted_at IS NOT NULL THEN 1 END)`.as("countDeleted"),
+        ])
+        .executeTakeFirstOrThrow();
+
+      return {
+        totalCharged: Number(result.totalCharged),
+        totalPaid: Number(result.totalPaid),
+        totalOutstanding: Number(result.totalOutstanding),
+        totalAbandoned: Number(result.totalAbandoned),
+        totalDeleted: Number(result.totalDeleted),
+        countPaid: Number(result.countPaid),
+        countUnpaid: Number(result.countUnpaid),
+        countPending: Number(result.countPending),
+        countAbandoned: Number(result.countAbandoned),
+        countDeleted: Number(result.countDeleted),
+      };
+    },
+  }),
+
+  chasePayment: defineAuthAction({
+    roles: ["admin"],
+    input: z.object({
+      chargeId: z.string(),
+    }),
+    handler: async ({ chargeId }) => {
+      const charge = await client
+        .selectFrom("charge")
+        .innerJoin("member", "member.id", "charge.member_id")
+        .where("charge.id", "=", chargeId)
+        .where("charge.paid_at", "is", null)
+        .where("charge.deleted_at", "is", null)
+        .select([
+          "charge.id",
+          "charge.description",
+          "charge.amount_pence",
+          "charge.charge_date",
+          "member.name as memberName",
+          "member.email as memberEmail",
+        ])
+        .executeTakeFirst();
+
+      if (!charge) {
+        throw new ActionError({
+          code: "NOT_FOUND",
+          message: "Charge not found or already paid/deleted",
+        });
+      }
+
+      const amountFormatted = new Intl.NumberFormat("en-GB", {
+        style: "currency",
+        currency: "GBP",
+      }).format(charge.amount_pence / 100);
+
+      await send({
+        to: charge.memberEmail,
+        subject: PaymentReminder.subject,
+        html: await render(
+          <PaymentReminder.component
+            imageBaseUrl={`${BASE_URL}/images`}
+            name={charge.memberName}
+            description={charge.description}
+            amount={amountFormatted}
+            chargeDate={formatDate(charge.charge_date, "dd/MM/yyyy")}
+            loginUrl={`${BASE_URL}/auth/login`}
+          />,
+          { pretty: true },
+        ),
+      });
+
+      return { success: true };
+    },
+  }),
 };
+
+function getChargeStatus(
+  paidAt: string | null,
+  paymentConfirmedAt: string | null,
+  deletedAt: string | null,
+  stripePaymentIntentId: string | null,
+  abandonedCutoff: string,
+  createdAt: string,
+): "paid" | "pending" | "unpaid" | "abandoned" | "deleted" {
+  if (deletedAt) return "deleted";
+  if (paidAt) return "paid";
+  if (paymentConfirmedAt) return "pending";
+  if (stripePaymentIntentId && createdAt < abandonedCutoff) return "abandoned";
+  return "unpaid";
+}

--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -2,13 +2,14 @@ import { useSession } from "@/lib/auth/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { navigate } from "astro:transitions/client";
 import { useState } from "react";
+import { ChargesTable } from "./ChargesTable";
 import { ContactSubmissionsTable } from "./ContactSubmissionsTable";
 import { JuniorsTable } from "./JuniorsTable";
 import { MemberTable } from "./MemberTable";
 
 const queryClient = new QueryClient();
 
-type Tab = "members" | "juniors" | "contacts";
+type Tab = "members" | "juniors" | "charges" | "contacts";
 
 export function AdminPanel() {
   const session = useSession();
@@ -54,6 +55,12 @@ export function AdminPanel() {
             Juniors
           </button>
           <button
+            className={`px-4 py-2 text-sm font-medium ${activeTab === "charges" ? "border-b-2 border-blue-500 text-blue-600" : "text-gray-500 hover:text-gray-700"}`}
+            onClick={() => setActiveTab("charges")}
+          >
+            Charges
+          </button>
+          <button
             className={`px-4 py-2 text-sm font-medium ${activeTab === "contacts" ? "border-b-2 border-blue-500 text-blue-600" : "text-gray-500 hover:text-gray-700"}`}
             onClick={() => setActiveTab("contacts")}
           >
@@ -62,6 +69,7 @@ export function AdminPanel() {
         </div>
         {activeTab === "members" && <MemberTable />}
         {activeTab === "juniors" && <JuniorsTable />}
+        {activeTab === "charges" && <ChargesTable />}
         {activeTab === "contacts" && <ContactSubmissionsTable />}
       </div>
     </QueryClientProvider>

--- a/src/components/admin/ChargesTable.tsx
+++ b/src/components/admin/ChargesTable.tsx
@@ -1,0 +1,446 @@
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/Table";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { actions } from "astro:actions";
+import { formatDate } from "date-fns";
+import { useEffect, useRef, useState } from "react";
+
+const PAGE_SIZE = 20;
+
+type ChargeStatus = "all" | "unpaid" | "pending" | "paid" | "abandoned";
+
+const currencyFormatter = new Intl.NumberFormat("en-GB", {
+  style: "currency",
+  currency: "GBP",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const statusBadgeMap: Record<
+  string,
+  { variant: "success" | "warning" | "info" | "destructive" | "default" | "secondary"; label: string }
+> = {
+  paid: { variant: "success", label: "Paid" },
+  unpaid: { variant: "warning", label: "Unpaid" },
+  pending: { variant: "info", label: "Pending" },
+  abandoned: { variant: "destructive", label: "Abandoned" },
+  deleted: { variant: "secondary", label: "Deleted" },
+};
+
+export function ChargesTable() {
+  const queryClient = useQueryClient();
+  const [page, setPage] = useState(1);
+  const [status, setStatus] = useState<ChargeStatus>("all");
+  const [showDeleted, setShowDeleted] = useState(false);
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [chasingChargeId, setChasingChargeId] = useState<string | null>(null);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+    debounceTimerRef.current = setTimeout(() => {
+      setDebouncedSearch(search);
+      setPage(1);
+    }, 300);
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, [search]);
+
+  const chargesQuery = useQuery({
+    queryKey: [
+      "admin",
+      "listAllCharges",
+      page,
+      PAGE_SIZE,
+      status,
+      showDeleted,
+      dateFrom,
+      dateTo,
+      debouncedSearch,
+    ],
+    queryFn: () =>
+      actions.admin.listAllCharges({
+        page,
+        pageSize: PAGE_SIZE,
+        status,
+        showDeleted,
+        dateFrom: dateFrom || undefined,
+        dateTo: dateTo || undefined,
+        search: debouncedSearch || undefined,
+      }),
+  });
+
+  const aggregatesQuery = useQuery({
+    queryKey: ["admin", "chargeAggregates", dateFrom, dateTo],
+    queryFn: () =>
+      actions.admin.getChargeAggregates({
+        dateFrom: dateFrom || undefined,
+        dateTo: dateTo || undefined,
+      }),
+  });
+
+  const chaseMutation = useMutation({
+    mutationFn: (chargeId: string) =>
+      actions.admin.chasePayment({ chargeId }),
+    onSuccess: () => {
+      setChasingChargeId(null);
+    },
+  });
+
+  const result = chargesQuery.data?.data;
+  const aggregates = aggregatesQuery.data?.data;
+  const totalPages = result
+    ? Math.max(1, Math.ceil(result.total / PAGE_SIZE))
+    : 1;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Summary Cards */}
+      {aggregates && (
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+          <SummaryCard
+            title="Total Charged"
+            amount={aggregates.totalCharged}
+            count={
+              aggregates.countPaid +
+              aggregates.countUnpaid +
+              aggregates.countPending +
+              aggregates.countAbandoned
+            }
+            variant="default"
+          />
+          <SummaryCard
+            title="Collected"
+            amount={aggregates.totalPaid}
+            count={aggregates.countPaid}
+            variant="success"
+          />
+          <SummaryCard
+            title="Outstanding"
+            amount={aggregates.totalOutstanding}
+            count={
+              aggregates.countUnpaid +
+              aggregates.countPending +
+              aggregates.countAbandoned
+            }
+            variant="warning"
+          />
+          <SummaryCard
+            title="Abandoned"
+            amount={aggregates.totalAbandoned}
+            count={aggregates.countAbandoned}
+            variant="destructive"
+          />
+        </div>
+      )}
+
+      {/* Filter bar */}
+      <div className="flex flex-wrap items-center gap-3">
+        <input
+          type="text"
+          placeholder="Search member or description..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-full max-w-xs rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        />
+        <select
+          value={status}
+          onChange={(e) => {
+            setStatus(e.target.value as ChargeStatus);
+            setPage(1);
+          }}
+          className="rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        >
+          <option value="all">All Statuses</option>
+          <option value="unpaid">Unpaid</option>
+          <option value="pending">Pending</option>
+          <option value="paid">Paid</option>
+          <option value="abandoned">Abandoned</option>
+        </select>
+        <div className="flex items-center gap-1">
+          <label htmlFor="charges-date-from" className="text-sm text-gray-500">
+            From
+          </label>
+          <input
+            id="charges-date-from"
+            type="date"
+            value={dateFrom}
+            onChange={(e) => {
+              setDateFrom(e.target.value);
+              setPage(1);
+            }}
+            className="rounded border border-gray-300 px-2 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          />
+        </div>
+        <div className="flex items-center gap-1">
+          <label htmlFor="charges-date-to" className="text-sm text-gray-500">
+            To
+          </label>
+          <input
+            id="charges-date-to"
+            type="date"
+            value={dateTo}
+            onChange={(e) => {
+              setDateTo(e.target.value);
+              setPage(1);
+            }}
+            className="rounded border border-gray-300 px-2 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          />
+        </div>
+        <label className="flex items-center gap-1.5 text-sm text-gray-600">
+          <input
+            type="checkbox"
+            checked={showDeleted}
+            onChange={(e) => {
+              setShowDeleted(e.target.checked);
+              setPage(1);
+            }}
+            className="rounded border-gray-300"
+          />
+          Show deleted
+        </label>
+        {(dateFrom || dateTo || search || status !== "all" || showDeleted) && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setSearch("");
+              setDebouncedSearch("");
+              setStatus("all");
+              setDateFrom("");
+              setDateTo("");
+              setShowDeleted(false);
+              setPage(1);
+            }}
+          >
+            Clear filters
+          </Button>
+        )}
+      </div>
+
+      {/* Loading / Error */}
+      {chargesQuery.isLoading && <p className="text-gray-500">Loading...</p>}
+      {chargesQuery.isError && (
+        <p className="text-red-600">Failed to load charges.</p>
+      )}
+
+      {/* Table */}
+      {result && (
+        <>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Date</TableHead>
+                <TableHead>Member</TableHead>
+                <TableHead>Description</TableHead>
+                <TableHead className="text-right">Amount</TableHead>
+                <TableHead>Source</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Payment Date</TableHead>
+                <TableHead>Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {result.charges.length === 0 && (
+                <TableRow>
+                  <TableCell
+                    colSpan={8}
+                    className="text-center text-gray-500"
+                  >
+                    No charges found.
+                  </TableCell>
+                </TableRow>
+              )}
+              {result.charges.map((charge) => {
+                const badge = statusBadgeMap[charge.status];
+                return (
+                  <TableRow
+                    key={charge.id}
+                    className={
+                      charge.status === "deleted" ? "opacity-60" : ""
+                    }
+                  >
+                    <TableCell>
+                      {formatDate(charge.chargeDate, "dd/MM/yyyy")}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-col">
+                        <span className="font-medium">
+                          {charge.memberName}
+                        </span>
+                        <span className="text-xs text-gray-500">
+                          {charge.memberEmail}
+                        </span>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      {charge.description}
+                      {charge.deletedReason && (
+                        <div className="text-xs text-gray-400">
+                          Deleted: {charge.deletedReason}
+                        </div>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {currencyFormatter.format(charge.amountPence / 100)}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="default">{charge.source}</Badge>
+                    </TableCell>
+                    <TableCell>
+                      {badge && (
+                        <Badge variant={badge.variant}>{badge.label}</Badge>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {charge.paidAt
+                        ? formatDate(charge.paidAt, "dd/MM/yyyy")
+                        : "-"}
+                    </TableCell>
+                    <TableCell>
+                      {(charge.status === "abandoned" ||
+                        charge.status === "unpaid") && (
+                        <>
+                          {chasingChargeId === charge.id ? (
+                            <div className="flex items-center gap-1">
+                              <Button
+                                variant="destructive"
+                                size="sm"
+                                disabled={chaseMutation.isPending}
+                                onClick={() =>
+                                  chaseMutation.mutate(charge.id, {
+                                    onSuccess: () => {
+                                      void queryClient.invalidateQueries({
+                                        queryKey: [
+                                          "admin",
+                                          "listAllCharges",
+                                        ],
+                                      });
+                                    },
+                                  })
+                                }
+                              >
+                                {chaseMutation.isPending
+                                  ? "Sending..."
+                                  : "Send"}
+                              </Button>
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => setChasingChargeId(null)}
+                              >
+                                Cancel
+                              </Button>
+                            </div>
+                          ) : (
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => setChasingChargeId(charge.id)}
+                            >
+                              Chase
+                            </Button>
+                          )}
+                          {chaseMutation.isError &&
+                            chasingChargeId === charge.id && (
+                              <p className="mt-1 text-xs text-red-600">
+                                Failed to send reminder.
+                              </p>
+                            )}
+                        </>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+
+          {/* Pagination */}
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-gray-500">
+              {result.total} charge{result.total !== 1 ? "s" : ""} total
+            </span>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page <= 1}
+              >
+                Previous
+              </Button>
+              <span className="text-gray-600">
+                Page {page} of {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  setPage((p) => Math.min(totalPages, p + 1))
+                }
+                disabled={page >= totalPages}
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function SummaryCard({
+  title,
+  amount,
+  count,
+  variant,
+}: {
+  title: string;
+  amount: number;
+  count: number;
+  variant: "default" | "success" | "warning" | "destructive";
+}) {
+  const borderColorMap: Record<string, string> = {
+    default: "",
+    success: "border-l-green-500",
+    warning: "border-l-yellow-500",
+    destructive: "border-l-red-500",
+  };
+
+  return (
+    <Card className={`border-l-4 ${borderColorMap[variant]}`}>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-gray-500">
+          {title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="text-xl font-bold">
+          {currencyFormatter.format(amount / 100)}
+        </div>
+        <p className="text-xs text-gray-500">
+          {count} charge{count !== 1 ? "s" : ""}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- New "Charges" tab in the admin panel with summary cards (Total Charged, Collected, Outstanding, Abandoned)
- Server-side filtering by status (paid/unpaid/pending/abandoned), date range, and text search
- Payment chase email functionality for unpaid charges
- New `PaymentReminder` email template

Closes #117

## Test plan
- [ ] Navigate to admin panel and verify "Charges" tab appears
- [ ] Verify summary cards show correct aggregated amounts
- [ ] Test filtering by status, date range, and search
- [ ] Test chase payment button sends reminder email
- [ ] Verify pagination works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)