### PR TITLE
fix: reconcile membership paid_until from Stripe subscriptions

### DIFF
--- a/src/components/admin/ChargesTable.tsx
+++ b/src/components/admin/ChargesTable.tsx
@@ -115,6 +115,7 @@ export function ChargesTable() {
       skippedSelfService: number;
       skippedNoMember: number;
       skippedFailed: number;
+      membershipsSynced: number;
       errors: string[];
     };
   } | null>(null);
@@ -138,7 +139,7 @@ export function ChargesTable() {
         const d = res.data;
         setSyncResult({
           type: "success",
-          message: `Sync complete: ${d.created} new charges imported, ${d.skippedDuplicate} duplicates skipped, ${d.skippedSelfService} self-service excluded, ${d.totalProcessed} total processed.`,
+          message: `Sync complete: ${d.created} new charges imported, ${d.skippedDuplicate} duplicates skipped, ${d.skippedSelfService} self-service excluded, ${d.membershipsSynced} memberships updated, ${d.totalProcessed} total processed.`,
           details: d,
         });
 


### PR DESCRIPTION
## Summary
- **Webhook renewal handler silently skipping membership updates**: `resolveSubscriptionMembershipMetadata` returned `undefined` when subscription metadata didn't match `membershipSchema` (older checkout-created subscriptions without propagated metadata). The `if (metadata)` block silently skipped `updateMembership`, leaving `paid_until` frozen at the initial value forever. Added a DB fallback that looks up the member's existing membership type, plus a `console.warn` so it's no longer silent.
- **Retroactive fix via sync**: After importing charges, the sync now checks each member's active Stripe subscriptions and updates `paid_until` from `current_period_end` when Stripe's date is later than ours.

## Test plan
- [ ] Run the sync and verify `paid_until` dates are corrected for affected members
- [ ] Run the sync again — memberships should not be re-updated (idempotent)
- [ ] Verify a renewal webhook for a subscription without metadata now correctly updates `paid_until`

🤖 Generated with [Claude Code](https://claude.com/claude-code)