### PR TITLE
fix: admin members table shows wrong membership data

### DIFF
--- a/src/actions/admin.tsx
+++ b/src/actions/admin.tsx
@@ -28,7 +28,11 @@ export const admin = {
       let baseQuery = client
         .selectFrom("user")
         .leftJoin("member", "member.email", "user.email")
-        .leftJoin("membership", "membership.member_id", "member.id");
+        .leftJoin("membership", (join) =>
+          join
+            .onRef("membership.member_id", "=", "member.id")
+            .on("membership.dependent_id", "is", null),
+        );
 
       if (search && search.trim().length > 0) {
         const term = `%${search.trim()}%`;
@@ -52,7 +56,11 @@ export const admin = {
         let q = client
           .selectFrom("user")
           .leftJoin("member", "member.email", "user.email")
-          .leftJoin("membership", "membership.member_id", "member.id");
+          .leftJoin("membership", (join) =>
+            join
+              .onRef("membership.member_id", "=", "member.id")
+              .on("membership.dependent_id", "is", null),
+          );
 
         if (search && search.trim().length > 0) {
           const term = `%${search.trim()}%`;


### PR DESCRIPTION
## Summary
- The admin members table joined `membership` without filtering `dependent_id IS NULL`, so members with junior dependents got NULL membership type/paid_until
- The member detail modal queried memberships correctly and showed the right data — this aligns the table query to match
- Adds `dependent_id IS NULL` filter to both the count and data queries in `listUsers`

## Test plan
- [ ] Open admin members panel, find a member with a social/adult membership who also has junior dependents
- [ ] Verify their membership type and paid until columns now display correctly in the table
- [ ] Verify the member detail modal still shows correct data
- [ ] Verify members without any membership still show "None" / "-"

🤖 Generated with [Claude Code](https://claude.com/claude-code)