### PR TITLE
docs: add structured Play-Cricket API reference

### DIFF
--- a/docs/play-cricket-api/README.md
+++ b/docs/play-cricket-api/README.md
@@ -1,0 +1,63 @@
+# Play-Cricket API Documentation
+
+Structured reference for the [Play-Cricket](https://play-cricket.com) API v2, maintained by the ECB.
+
+## Base URL
+
+```
+https://play-cricket.com/api/v2
+```
+
+> The official docs use `http://` in examples but `https://` should be used in practice.
+
+## Authentication
+
+All endpoints require an `api_token` query parameter. Tokens are issued per-club/league site.
+
+```
+?api_token=YOUR_TOKEN
+```
+
+## Endpoints
+
+| Endpoint | Description | Doc |
+|----------|-------------|-----|
+| [Teams](./teams.md) | List teams for a site | `GET /sites/{site_id}/teams.json` |
+| [Players](./players.md) | List players for a site | `GET /sites/{site_id}/players` |
+| [Competitions](./competitions.md) | List divisions/cups for a league & season | `GET /competitions.json` |
+| [Teams in Division](./teams-in-division.md) | List teams in a division/cup | `GET /competition_teams.json` |
+| [Match Summary](./match-summary.md) | List fixtures & matches (lightweight) | `GET /matches.json` |
+| [Result Summary](./result-summary.md) | Matches with results (includes innings totals) | `GET /result_summary.json` |
+| [Match Detail](./match-detail.md) | Full scorecard for a single match | `GET /match_detail.json` |
+| [League Table](./league-table.md) | Calculated league table for a division | `GET /league_table.json` |
+
+## Common Patterns
+
+### Date parameters
+
+Date strings use `dd/mm/yyyy` format throughout (UK-style).
+
+Two date-range patterns appear across endpoints:
+
+- **`from_entry_date` / `end_entry_date`** - filter by when the record was last updated in Play-Cricket (useful for incremental sync)
+- **`from_match_date` / `end_match_date`** - filter by the actual match date
+
+### Status field
+
+Many responses include a `status` field with values:
+- `"New"` - active/current record
+- `"Deleted"` - soft-deleted record
+
+### Published field
+
+Match-related responses include `published` (`"Yes"` / `"No"`). Unpublished fixtures are created in league sites but not yet visible on club sites.
+
+### Empty strings
+
+The API returns empty strings `""` for null/missing values rather than `null`.
+
+## Access Policy
+
+The API is primarily for clubs and leagues to extract their own data. Commercial/non-profit partners require ECB onboarding. The ECB recommends smaller projects allow clubs to provide their own API tokens.
+
+See: [Play-Cricket API Access](https://play-cricket.ecb.co.uk/hc/en-us/articles/24640412683037)

--- a/docs/play-cricket-api/competitions.md
+++ b/docs/play-cricket-api/competitions.md
@@ -1,0 +1,53 @@
+# Competitions API (Divisions & Cups)
+
+List divisions or cups for a league in a given season.
+
+## Request
+
+```
+GET /api/v2/competitions.json
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `api_token` | string | Yes | API token |
+| `league_id` | int | Yes | League ID |
+| `season` | string | Yes | Season year (e.g. `"2024"`) |
+| `competition_type` | string | Yes | `"divisions"` or `"cups"` |
+
+## Example Request
+
+```
+GET https://play-cricket.com/api/v2/competitions.json?league_id=296&season=2024&competition_type=divisions&api_token=xxxxx
+```
+
+## Response
+
+```json
+{
+  "competitions": [
+    {
+      "id": 69548,
+      "name": "Division 1"
+    },
+    {
+      "id": 69563,
+      "name": "Division 10 North"
+    }
+  ]
+}
+```
+
+## Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | int | Competition (division/cup) ID - unique per season |
+| `name` | string | Competition name |
+
+## Notes
+
+- The returned `id` is unique per division-season combination. The same division in different seasons will have different IDs.
+- Use the returned `id` as `division_id` or `cup_id` in other endpoints (Match Summary, League Table, etc).

--- a/docs/play-cricket-api/league-table.md
+++ b/docs/play-cricket-api/league-table.md
@@ -1,0 +1,114 @@
+# League Table API
+
+Retrieve a calculated league table for a division. This endpoint triggers server-side calculation before returning results, so may be slower than other endpoints.
+
+## Request
+
+```
+GET /api/v2/league_table.json
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `api_token` | string | Yes | API token |
+| `division_id` | int | Yes | Division ID (unique per division+season, so no season param needed) |
+
+## Example Request
+
+```
+GET https://play-cricket.com/api/v2/league_table.json?division_id=70999&api_token=xxxxx
+```
+
+## Response
+
+The response has three sections: column headings, row values, and a key legend.
+
+```json
+{
+  "league_table": [
+    {
+      "id": 71768,
+      "division_name": "1st XI Premier Division (Time & Overs)",
+      "headings": {
+        "column_1": "Team",
+        "column_2": "p",
+        "column_3": "w24",
+        "column_4": "w20"
+      },
+      "values": [
+        {
+          "position": "1",
+          "team_id": "9073",
+          "column_1": "Rugby CC",
+          "column_2": "22",
+          "column_3": "3",
+          "column_4": "13"
+        },
+        {
+          "position": "2",
+          "team_id": "11558",
+          "column_1": "Bedworth CC",
+          "column_2": "22",
+          "column_3": "2",
+          "column_4": "13"
+        }
+      ],
+      "key": "p - Played, w24 - Win 24pts (24), w20 - Win 20pts (20)"
+    }
+  ]
+}
+```
+
+## Response Fields
+
+### Table-level
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | int | Table ID |
+| `division_name` | string | Division name with match format |
+| `headings` | object | Column definitions (see below) |
+| `values` | array | Row data, one per team in position order |
+| `key` | string | Legend explaining column abbreviations |
+
+### Headings object
+
+Dynamic keys `column_1`, `column_2`, ... `column_N`. Values are the column heading labels. Only columns with data are included (null-for-all-teams columns are omitted).
+
+### Values array (per team)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `position` | string | League position (rank) |
+| `team_id` | string | Team ID |
+| `column_1` ... `column_N` | string | Values corresponding to the headings |
+
+### Common Column Abbreviations
+
+These vary by league configuration. Common ones from the key:
+
+| Abbreviation | Meaning | Points |
+|--------------|---------|--------|
+| `p` | Played | - |
+| `w24` | Win 24pts | 24 |
+| `w20` | Win 20pts | 20 |
+| `wd` | Winning draw | - |
+| `ld4` | Losing draw >=75% | 4 |
+| `ld2` | Losing draw <75% | 2 |
+| `t` | Tied | 10 |
+| `a` | Abandoned | 4 |
+| `l` | Loss | - |
+| `BatP` | Batting Bonus Points | - |
+| `BowlP` | Bowling Bonus Points | - |
+| `Pen` | Penalty Points | - |
+| `Pts` | Total Points | - |
+
+## Notes
+
+- The `division_id` is unique per division-season combination, so no `season` parameter is needed.
+- Column structure is fully dynamic - different leagues will have different columns depending on their scoring rules.
+- The `key` field provides the human-readable legend to decode column abbreviations. Parse this to map column headings to their full descriptions.
+- Columns with null values for all teams are excluded from the response.
+- Zero values (`"0"`) are included in the response (not treated as null).

--- a/docs/play-cricket-api/match-detail.md
+++ b/docs/play-cricket-api/match-detail.md
@@ -1,0 +1,317 @@
+# Match Detail API
+
+Full scorecard for a single match, including team sheets, batting, bowling, and fall of wickets.
+
+## Request
+
+```
+GET /api/v2/match_detail.json
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `api_token` | string | Yes | API token |
+| `match_id` | int | Yes | Match ID (from Match Summary or Result Summary) |
+
+## Example Request
+
+```
+GET https://play-cricket.com/api/v2/match_detail.json?match_id=123456&api_token=xxxxx
+```
+
+## Response
+
+The response is a single-element array containing the full match object.
+
+```json
+{
+  "match_details": [
+    {
+      "id": 123456,
+      "status": "New",
+      "published": "Yes",
+      "last_updated": "01/02/2024",
+      "league_name": "Anything But Collies League",
+      "league_id": "14792",
+      "competition_name": "Division 1",
+      "competition_id": "71400",
+      "competition_type": "League",
+      "match_type": "Declaration",
+      "game_type": "Standard",
+      "match_id": "1234567",
+      "match_date": "10/06/2024",
+      "match_time": "10:45",
+      "ground_name": "Peter May Sports Centre",
+      "ground_id": "13909",
+      "home_team_name": "3rd XI",
+      "home_team_id": "12640",
+      "home_club_name": "Chingford CC",
+      "home_club_id": "1835",
+      "away_team_name": "2nd XI",
+      "away_team_id": "208057",
+      "away_club_name": "Chingford Quackers CC",
+      "away_club_id": "14793",
+      "umpire_1_name": "...",
+      "umpire_1_id": "...",
+      "umpire_2_name": "...",
+      "umpire_2_id": "...",
+      "umpire_3_id": "",
+      "referee_id": "",
+      "scorer_1_name": "...",
+      "scorer_1_id": "...",
+      "scorer_2_name": "...",
+      "scorer_2_id": "...",
+      "toss_won_by_team_id": "12640",
+      "toss": "Chingford CC - 3rd XI won the toss and elected to bat",
+      "batted_first": "12640",
+      "no_of_overs": "",
+      "no_of_innings": "1",
+      "no_of_days": "",
+      "no_of_players": "",
+      "no_of_reserves": "",
+      "result": "W",
+      "result_description": "Chingford Quackers CC - 2nd XI - Won",
+      "result_applied_to": "208057",
+      "match_notes": "What a match!",
+      "points": [],
+      "match_result_types": [],
+      "players": [],
+      "innings": []
+    }
+  ]
+}
+```
+
+## Match-Level Fields
+
+Same as [Result Summary](./result-summary.md) plus:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `match_id` | string | Match ID (also appears as top-level `id`) |
+| `ground_name` | string | Ground name |
+| `ground_id` | string | Ground ID |
+| `scorer_1_name` | string | First scorer name |
+| `scorer_1_id` | string | First scorer ID |
+| `scorer_2_name` | string | Second scorer name |
+| `scorer_2_id` | string | Second scorer ID |
+| `no_of_days` | string | Number of days (multi-day matches) |
+| `no_of_players` | string | Players per side |
+| `no_of_reserves` | string | Reserves per side |
+
+## Points Array
+
+Per-team points breakdown (two entries, one per team):
+
+```json
+{
+  "team_id": "12640",
+  "game_points": "0",
+  "penalty_points": "1",
+  "bonus_points_together": "",
+  "bonus_points_batting": "3",
+  "bonus_points_bowling": "0",
+  "bonus_points_2nd_innings_together": "",
+  "bonus_points_2nd_innings_batting": "",
+  "bonus_points_2nd_innings_bowling": ""
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `team_id` | string | Team ID |
+| `game_points` | string | Points for the game result |
+| `penalty_points` | string | Penalty points |
+| `bonus_points_together` | string | Combined bonus (if league uses single bonus) |
+| `bonus_points_batting` | string | Batting bonus points |
+| `bonus_points_bowling` | string | Bowling bonus points |
+| `bonus_points_2nd_innings_together` | string | 2nd innings combined bonus |
+| `bonus_points_2nd_innings_batting` | string | 2nd innings batting bonus |
+| `bonus_points_2nd_innings_bowling` | string | 2nd innings bowling bonus |
+
+## Match Result Types Array
+
+Available result options for this match. Each entry is a tuple:
+
+```json
+[
+  ["Chingford CC - 3rd XI - Won", "582111#12640"],
+  ["Chingford Quackers CC - 2nd XI - Won", "582111#208057"],
+  ["Tied", 582117],
+  ["Cancelled", 582113],
+  ["Abandoned", 582114],
+  ["Chingford CC - 3rd XI - Conceded", "582115#208057"],
+  ["Chingford Quackers CC - 2nd XI - Conceded", "582116#12640"],
+  ["Match In Progress", 14]
+]
+```
+
+Format: `[description, result_code]` where team-specific results use `"code#team_id"`.
+
+## Players Array
+
+Team sheets with two entries: `home_team` and `away_team`.
+
+```json
+{
+  "players": [
+    {
+      "home_team": [
+        {
+          "position": 1,
+          "player_name": "Chew Leonard",
+          "player_id": 3778631,
+          "captain": false,
+          "wicket_keeper": false
+        }
+      ]
+    },
+    {
+      "away_team": [
+        {
+          "position": 1,
+          "player_name": "Amber Duck",
+          "player_id": 3778926,
+          "captain": true,
+          "wicket_keeper": false
+        }
+      ]
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `position` | int | Batting order position |
+| `player_name` | string | Player name |
+| `player_id` | int | Player (member) ID |
+| `captain` | boolean | Is team captain |
+| `wicket_keeper` | boolean | Is wicket keeper |
+
+## Innings Array
+
+One entry per innings bowled. Each contains batting (`bat`), fall of wickets (`fow`), and bowling (`bowl`).
+
+### Innings-Level Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `team_batting_name` | string | Batting team name |
+| `team_batting_id` | string | Batting team ID |
+| `innings_number` | int | Innings number |
+| `extra_byes` | string | Byes |
+| `extra_leg_byes` | string | Leg byes |
+| `extra_wides` | string | Wides |
+| `extra_no_balls` | string | No balls |
+| `extra_penalty_runs` | string | Penalty runs |
+| `penalties_runs_awarded_in_other_innings` | string | Penalty runs from other innings |
+| `total_extras` | string | Total extras |
+| `runs` | string | Total runs |
+| `wickets` | string | Wickets lost |
+| `overs` | string | Overs faced (e.g. `"10"`, `"9.5"`) |
+| `declared` | boolean | Whether the innings was declared |
+| `revised_target_runs` | string | D/L revised target runs |
+| `revised_target_overs` | string | D/L revised target overs |
+
+### Batting (`bat`) Array
+
+```json
+{
+  "position": "1",
+  "batsman_name": "Chew Leonard",
+  "batsman_id": "3778631",
+  "how_out": "b",
+  "fielder_name": "",
+  "fielder_id": "",
+  "bowler_name": "Amber Duck",
+  "bowler_id": "3778926",
+  "runs": "30",
+  "fours": "2",
+  "sixes": "1",
+  "balls": "21"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `position` | string | Batting order position |
+| `batsman_name` | string | Batsman name |
+| `batsman_id` | string | Batsman ID |
+| `how_out` | string | Dismissal mode (see below) |
+| `fielder_name` | string | Fielder involved (if applicable) |
+| `fielder_id` | string | Fielder ID |
+| `bowler_name` | string | Bowler who took the wicket |
+| `bowler_id` | string | Bowler ID |
+| `runs` | string | Runs scored |
+| `fours` | string | Number of fours |
+| `sixes` | string | Number of sixes |
+| `balls` | string | Balls faced |
+
+#### Dismissal Modes (`how_out`)
+
+| Code | Meaning |
+|------|---------|
+| `"b"` | Bowled |
+| `"ct"` | Caught |
+| `"no"` | Not out |
+| `"lbw"` | Leg before wicket |
+| `"ro"` | Run out |
+| `"st"` | Stumped |
+| `"hw"` | Hit wicket |
+| `"rtd"` | Retired |
+| `"dnb"` | Did not bat |
+
+> The full set of dismissal codes is not documented by the ECB. The above are observed values.
+
+### Fall of Wickets (`fow`) Array
+
+```json
+{
+  "runs": "40",
+  "wickets": 1,
+  "batsman_out_name": "Chew Leonard",
+  "batsman_out_id": "3778631",
+  "batsman_in_name": "Mars Leonard",
+  "batsman_in_id": "3778630",
+  "batsman_in_runs": "10"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `runs` | string | Team total when wicket fell |
+| `wickets` | int | Wicket number (1st, 2nd, etc.) |
+| `batsman_out_name` | string | Dismissed batsman |
+| `batsman_out_id` | string | Dismissed batsman ID |
+| `batsman_in_name` | string | Non-striker at time of dismissal |
+| `batsman_in_id` | string | Non-striker ID |
+| `batsman_in_runs` | string | Non-striker's score at time of dismissal |
+
+### Bowling (`bowl`) Array
+
+```json
+{
+  "bowler_name": "Amber Duck",
+  "bowler_id": "3778926",
+  "overs": "5",
+  "maidens": "2",
+  "runs": "50",
+  "wides": "0",
+  "wickets": "1",
+  "no_balls": "0"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `bowler_name` | string | Bowler name |
+| `bowler_id` | string | Bowler ID |
+| `overs` | string | Overs bowled |
+| `maidens` | string | Maiden overs |
+| `runs` | string | Runs conceded |
+| `wides` | string | Wides bowled |
+| `wickets` | string | Wickets taken |
+| `no_balls` | string | No balls bowled |

--- a/docs/play-cricket-api/match-summary.md
+++ b/docs/play-cricket-api/match-summary.md
@@ -1,0 +1,88 @@
+# Match Summary API
+
+List fixtures (upcoming) and matches (with results). Lightweight - use for discovering match IDs, then fetch full details via [Match Detail](./match-detail.md).
+
+## Request
+
+```
+GET /api/v2/matches.json
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `api_token` | string | Yes | API token |
+| `site_id` | int | Yes | Play-Cricket site ID |
+| `season` | string | No | Season year (e.g. `"2024"`) |
+| `division_id` | int | No | Filter to a specific division |
+| `cup_id` | int | No | Filter to a specific cup |
+| `team_id` | int | No | Filter to a specific team |
+| `competition_type` | string | No | `"League"`, `"Cup"`, or `"Friendly"` |
+| `from_entry_date` | string | No | `dd/mm/yyyy` - records updated on or after |
+| `end_entry_date` | string | No | `dd/mm/yyyy` - records updated on or before |
+| `include_unpublished` | string | No | `"yes"` to include unpublished fixtures |
+
+## Typical Usage
+
+1. At season start: fetch all fixtures for the season
+2. Periodically: use `from_entry_date` to pick up additions, amendments, and deletions since last sync
+
+## Example Request
+
+```
+GET https://play-cricket.com/api/v2/matches.json?site_id=1234&season=2024&api_token=xxxxx
+```
+
+## Response
+
+```json
+{
+  "matches": [
+    {
+      "id": 100007,
+      "status": "New",
+      "published": "Yes",
+      "last_updated": "01/02/2024",
+      "season": "2024",
+      "match_date": "31/08/2024",
+      "match_time": "11:00",
+      "home_club_name": "Chingford Quackers CC",
+      "home_team_name": "1st XI",
+      "home_club_id": "2220",
+      "home_team_id": 161463,
+      "away_club_name": "Old Loughts CC",
+      "away_team_name": "1st XI",
+      "away_club_id": 6908,
+      "away_team_id": 157998,
+      "division_id": "90909"
+    }
+  ]
+}
+```
+
+## Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | int | Match ID (use with Match Detail API) |
+| `status` | string | `"New"` or `"Deleted"` |
+| `published` | string | `"Yes"` or `"No"` |
+| `last_updated` | string | Date last modified (`dd/mm/yyyy`) |
+| `season` | string | Season year |
+| `match_date` | string | Date of match (`dd/mm/yyyy`) |
+| `match_time` | string | Start time (`HH:MM`) |
+| `home_club_name` | string | Home club name |
+| `home_team_name` | string | Home team name |
+| `home_club_id` | string | Home club ID |
+| `home_team_id` | int | Home team ID |
+| `away_club_name` | string | Away club name |
+| `away_team_name` | string | Away team name |
+| `away_club_id` | int | Away club ID |
+| `away_team_id` | int | Away team ID |
+| `division_id` | string | Division ID (if applicable) |
+
+## Notes
+
+- Unpublished matches are fixtures created in league sites but not yet published to the front end or club sites. Most consumers will not need these.
+- The `status: "Deleted"` value indicates a soft-deleted record. Use `from_entry_date` to detect deletions during incremental sync.

--- a/docs/play-cricket-api/players.md
+++ b/docs/play-cricket-api/players.md
@@ -1,0 +1,61 @@
+# Players API
+
+List players (members) for a club site.
+
+## Request
+
+```
+GET /api/v2/sites/{site_id}/players
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `api_token` | string | Yes | API token |
+| `site_id` | int | Yes | Play-Cricket site ID (path parameter) |
+| `include_everyone` | string | No | Set to `"yes"` to include all members with any active role (not just squad members) |
+| `include_historic` | string | No | Set to `"yes"` to also include members with historic squad roles |
+
+## Default Behaviour
+
+Without optional parameters, returns only members with an **active squad role** at the club.
+
+## Example Request
+
+```
+GET https://play-cricket.com/api/v2/sites/1234/players?api_token=xxxxx&include_everyone=yes
+```
+
+## Response
+
+```json
+{
+  "players": [
+    {
+      "member_id": 12345,
+      "name": "Bugs Bunny"
+    },
+    {
+      "member_id": 224466,
+      "name": "Roger Rabbit"
+    }
+  ]
+}
+```
+
+## Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `member_id` | int | Unique member ID |
+| `name` | string | Full name |
+
+## Filter Behaviour
+
+| Parameters | Members returned |
+|------------|-----------------|
+| _(none)_ | Active squad role only |
+| `include_everyone=yes` | Any active role at the club |
+| `include_historic=yes` | Active squad + historic squad roles |
+| Both | Any active role + historic squad roles |

--- a/docs/play-cricket-api/result-summary.md
+++ b/docs/play-cricket-api/result-summary.md
@@ -1,0 +1,206 @@
+# Result Summary API
+
+Returns matches that have a result attached (including "match in progress"). More detailed than Match Summary but only includes completed/in-progress matches. Includes innings totals and points.
+
+## Request
+
+```
+GET /api/v2/result_summary.json
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `api_token` | string | Yes | API token |
+| `site_id` | int | Yes | Play-Cricket site ID |
+| `season` | string | Yes | Season year (e.g. `"2024"`) |
+| `division_id` | int | No | Filter to a specific division |
+| `cup_id` | int | No | Filter to a specific cup |
+| `team_id` | int | No | Filter to a specific team |
+| `competition_type` | string | No | `"League"`, `"Cup"`, or `"Friendly"` |
+| `from_match_date` | string | No | `dd/mm/yyyy` - matches on or after this date |
+| `end_match_date` | string | No | `dd/mm/yyyy` - matches on or before this date |
+| `from_entry_date` | string | No | `dd/mm/yyyy` - records updated on or after |
+| `end_entry_date` | string | No | `dd/mm/yyyy` - records updated on or before |
+
+## Example Request
+
+```
+GET https://play-cricket.com/api/v2/result_summary.json?site_id=1234&season=2024&api_token=xxxxx
+```
+
+## Response
+
+```json
+{
+  "result_summary": [
+    {
+      "id": 3048818,
+      "status": "New",
+      "published": "Yes",
+      "last_updated": "17/09/2024",
+      "league_name": "Derbyshire County Cricket League",
+      "league_id": "296",
+      "competition_name": "ECB Premier Division",
+      "competition_id": "69547",
+      "competition_type": "League",
+      "match_type": "Limited Overs",
+      "game_type": "Standard",
+      "match_date": "16/09/2024",
+      "match_time": "12:00",
+      "ground_name": "Raygar Arena",
+      "ground_id": "12682",
+      "home_team_name": "1st XI",
+      "home_team_id": "7960",
+      "home_club_name": "Alvaston & Boulton CC",
+      "home_club_id": "690",
+      "away_team_name": "1st XI",
+      "away_team_id": "50478",
+      "away_club_name": "Cutthorpe CC",
+      "away_club_id": "143",
+      "umpire_1_name": "Peter Gibson",
+      "umpire_1_id": "3218559",
+      "umpire_2_name": "Adam Hitchcock",
+      "umpire_2_id": "12683",
+      "umpire_3_id": "",
+      "referee_id": "",
+      "scorer_1_id": "",
+      "scorer_2_id": "",
+      "toss_won_by_team_id": "50478",
+      "toss": "Cutthorpe CC - 1st XI won the toss and elected to bat",
+      "batted_first": "50478",
+      "no_of_overs": "",
+      "no_of_innings": "1",
+      "result": "W",
+      "result_description": "Alvaston & Boulton CC - 1st XI - Won bat second 27",
+      "result_applied_to": "7960",
+      "match_notes": "<br><b>Cutthorpe innings:</b> ...",
+      "points": [
+        {
+          "team_id": 7960,
+          "game_points": "27",
+          "penalty_points": "0.0",
+          "bonus_points_together": "",
+          "bonus_points_batting": "0.0",
+          "bonus_points_bowling": "0.0",
+          "bonus_points_2nd_innings_together": ""
+        },
+        {
+          "team_id": 50478,
+          "game_points": "0",
+          "penalty_points": "0.0",
+          "bonus_points_together": "",
+          "bonus_points_batting": "5.0",
+          "bonus_points_bowling": "1.0",
+          "bonus_points_2nd_innings_together": ""
+        }
+      ],
+      "innings": [
+        {
+          "team_batting_id": "50478",
+          "innings_number": 1,
+          "extra_byes": "1",
+          "extra_leg_byes": "10",
+          "extra_wides": "9",
+          "extra_no_balls": "7",
+          "extra_penalty_runs": "0",
+          "penalties_runs_awarded_in_other_innings": "0",
+          "total_extras": "27",
+          "runs": "287",
+          "wickets": "7",
+          "overs": "50.0",
+          "declared": false,
+          "revised_target_runs": "",
+          "revised_target_overs": ""
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Response Fields
+
+### Match-level fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | int | Match ID |
+| `status` | string | `"New"` or `"Deleted"` |
+| `published` | string | `"Yes"` or `"No"` |
+| `last_updated` | string | `dd/mm/yyyy` |
+| `league_name` | string | League name |
+| `league_id` | string | League ID |
+| `competition_name` | string | Division/cup name |
+| `competition_id` | string | Division/cup ID |
+| `competition_type` | string | `"League"`, `"Cup"`, or `"Friendly"` |
+| `match_type` | string | e.g. `"Limited Overs"`, `"Declaration"` |
+| `game_type` | string | e.g. `"Standard"` |
+| `match_date` | string | `dd/mm/yyyy` |
+| `match_time` | string | `HH:MM` |
+| `ground_name` | string | Ground name |
+| `ground_id` | string | Ground ID |
+| `home_team_name` | string | Home team name |
+| `home_team_id` | string | Home team ID |
+| `home_club_name` | string | Home club name |
+| `home_club_id` | string | Home club ID |
+| `away_team_name` | string | Away team name |
+| `away_team_id` | string | Away team ID |
+| `away_club_name` | string | Away club name |
+| `away_club_id` | string | Away club ID |
+| `umpire_1_name` | string | First umpire name |
+| `umpire_1_id` | string | First umpire ID |
+| `umpire_2_name` | string | Second umpire name |
+| `umpire_2_id` | string | Second umpire ID |
+| `umpire_3_id` | string | Third umpire ID |
+| `referee_id` | string | Referee ID |
+| `scorer_1_id` | string | First scorer ID |
+| `scorer_2_id` | string | Second scorer ID |
+| `toss_won_by_team_id` | string | Team ID that won the toss |
+| `toss` | string | Toss description text |
+| `batted_first` | string | Team ID that batted first |
+| `no_of_overs` | string | Number of overs (if applicable) |
+| `no_of_innings` | string | Number of innings per side |
+| `result` | string | Result code (e.g. `"W"`) |
+| `result_description` | string | Human-readable result |
+| `result_applied_to` | string | Team ID the result applies to |
+| `match_notes` | string | Free-text notes (may contain HTML) |
+
+### Points object
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `team_id` | int | Team ID |
+| `game_points` | string | Points awarded for the game result |
+| `penalty_points` | string | Penalty points deducted |
+| `bonus_points_together` | string | Combined bonus points (if league uses single bonus) |
+| `bonus_points_batting` | string | Batting bonus points |
+| `bonus_points_bowling` | string | Bowling bonus points |
+| `bonus_points_2nd_innings_together` | string | 2nd innings combined bonus (multi-innings matches) |
+
+### Innings object
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `team_batting_id` | string | Team ID of the batting side |
+| `innings_number` | int | Innings number (1, 2, etc.) |
+| `extra_byes` | string | Byes |
+| `extra_leg_byes` | string | Leg byes |
+| `extra_wides` | string | Wides |
+| `extra_no_balls` | string | No balls |
+| `extra_penalty_runs` | string | Penalty runs |
+| `penalties_runs_awarded_in_other_innings` | string | Penalty runs from other innings |
+| `total_extras` | string | Total extras |
+| `runs` | string | Total runs scored |
+| `wickets` | string | Wickets lost |
+| `overs` | string | Overs faced (e.g. `"50.0"`, `"46.3"`) |
+| `declared` | boolean | Whether the innings was declared |
+| `revised_target_runs` | string | D/L revised target runs |
+| `revised_target_overs` | string | D/L revised target overs |
+
+## Notes
+
+- Unlike Match Summary, this endpoint **requires** the `season` parameter.
+- Does not include individual batting/bowling figures - use [Match Detail](./match-detail.md) for full scorecards.
+- `match_notes` may contain HTML (e.g. `<br>`, `<b>` tags).

--- a/docs/play-cricket-api/teams-in-division.md
+++ b/docs/play-cricket-api/teams-in-division.md
@@ -1,0 +1,52 @@
+# Teams in Division API
+
+List teams in a specific division or cup competition.
+
+## Request
+
+```
+GET /api/v2/competition_teams.json
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `api_token` | string | Yes | API token |
+| `id` | int | Yes | Competition (division/cup) ID |
+
+## Example Request
+
+```
+GET https://play-cricket.com/api/v2/competition_teams.json?id=12345&api_token=xxxxx
+```
+
+## Response
+
+```json
+{
+  "competition_teams": [
+    {
+      "club_id": "1234",
+      "club_name": "Chingford CC",
+      "team_id": "10001",
+      "team_name": "2nd XI"
+    },
+    {
+      "club_id": "5566",
+      "club_name": "Chingford Quackers CC",
+      "team_id": "23232",
+      "team_name": "2nd XI"
+    }
+  ]
+}
+```
+
+## Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `club_id` | string | Club ID |
+| `club_name` | string | Club name |
+| `team_id` | string | Team ID |
+| `team_name` | string | Team name (e.g. `"2nd XI"`) |

--- a/docs/play-cricket-api/teams.md
+++ b/docs/play-cricket-api/teams.md
@@ -1,0 +1,57 @@
+# Teams API
+
+List teams belonging to a site (club or CCB).
+
+## Request
+
+```
+GET /api/v2/sites/{site_id}/teams.json
+```
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `api_token` | string | Yes | API token |
+| `site_id` | int | Yes | Play-Cricket site ID (path parameter) |
+| `site_type` | string | No | `"club"` or `"CCB"` |
+| `from_entry_date` | string | No | `dd/mm/yyyy` - records updated on or after this date |
+| `end_entry_date` | string | No | `dd/mm/yyyy` - records updated on or before this date |
+
+## Example Request
+
+```
+GET https://play-cricket.com/api/v2/sites/1234/teams.json?api_token=xxxxx
+```
+
+## Response
+
+```json
+{
+  "teams": [
+    {
+      "id": "",
+      "status": "",
+      "last_updated": "",
+      "site_id": "",
+      "team_name": "",
+      "other_team_name": "",
+      "nickname": "",
+      "team_captain": ""
+    }
+  ]
+}
+```
+
+## Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | int | Team ID |
+| `status` | string | `"New"` or `"Deleted"` |
+| `last_updated` | string | Date of last update |
+| `site_id` | int | Parent site ID |
+| `team_name` | string | Official team name (e.g. `"1st XI"`) |
+| `other_team_name` | string | Alternative team name |
+| `nickname` | string | Team nickname |
+| `team_captain` | string | Captain name |


### PR DESCRIPTION
## Summary
- Consolidates the ECB's poorly-documented Play-Cricket API docs (scattered across help centre pages and PDFs) into a structured reference under `docs/play-cricket-api/`
- Covers all 8 endpoints: Teams, Players, Competitions, Teams in Division, Match Summary, Result Summary, Match Detail, League Table
- Each doc includes endpoint URL, parameters, full response schema with field descriptions, and usage notes

## Test plan
- [x] Docs-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)