### PR TITLE
feat: full match scorecards from Play-Cricket API

### DIFF
--- a/src/actions/play-cricket.ts
+++ b/src/actions/play-cricket.ts
@@ -29,6 +29,77 @@ export const playCricket = {
     },
   }),
 
+  getMatchDetail: defineAction({
+    input: z.object({
+      matchId: z.string(),
+    }),
+    handler: async ({ matchId }) => {
+      const { match_details } = await playCricketApi.getMatchDetail({
+        matchId,
+      });
+      const match = match_details[0];
+      if (!match) return null;
+
+      return {
+        homeTeamName: `${match.home_club_name} ${match.home_team_name}`,
+        homeTeamId: match.home_team_id,
+        awayTeamName: `${match.away_club_name} ${match.away_team_name}`,
+        awayTeamId: match.away_team_id,
+        toss: match.toss,
+        result: match.result,
+        resultDescription: match.result_description,
+        resultAppliedTo: match.result_applied_to,
+        battedFirst: match.batted_first,
+        innings: match.innings.map((inn) => ({
+          teamBattingName: inn.team_batting_name,
+          teamBattingId: inn.team_batting_id,
+          inningsNumber: inn.innings_number,
+          batting: inn.bat.map((b) => ({
+            position: parseInt(b.position, 10) || 0,
+            name: b.batsman_name,
+            id: b.batsman_id,
+            howOut: b.how_out,
+            fielderName: b.fielder_name,
+            bowlerName: b.bowler_name,
+            runs: parseInt(b.runs, 10) || 0,
+            balls: parseInt(b.balls, 10) || 0,
+            fours: parseInt(b.fours, 10) || 0,
+            sixes: parseInt(b.sixes, 10) || 0,
+          })),
+          bowling: inn.bowl.map((b) => ({
+            name: b.bowler_name,
+            id: b.bowler_id,
+            overs: b.overs,
+            maidens: parseInt(b.maidens, 10) || 0,
+            runs: parseInt(b.runs, 10) || 0,
+            wickets: parseInt(b.wickets, 10) || 0,
+            wides: parseInt(b.wides, 10) || 0,
+            noBalls: parseInt(b.no_balls, 10) || 0,
+          })),
+          fallOfWickets: inn.fow.map((f) => ({
+            wicketNumber: f.wickets,
+            runs: parseInt(f.runs, 10) || 0,
+            batsmanOutName: f.batsman_out_name,
+          })),
+          extras: {
+            byes: parseInt(inn.extra_byes, 10) || 0,
+            legByes: parseInt(inn.extra_leg_byes, 10) || 0,
+            wides: parseInt(inn.extra_wides, 10) || 0,
+            noBalls: parseInt(inn.extra_no_balls, 10) || 0,
+            penalties: parseInt(inn.extra_penalty_runs, 10) || 0,
+            total: parseInt(inn.total_extras, 10) || 0,
+          },
+          total: {
+            runs: parseInt(inn.runs, 10) || 0,
+            wickets: parseInt(inn.wickets, 10) || 0,
+            overs: inn.overs,
+            declared: inn.declared,
+          },
+        })),
+      };
+    },
+  }),
+
   getLeagueTable: defineAction({
     input: z.object({
       divisionId: z.string(),

--- a/src/components/CalendarItem.astro
+++ b/src/components/CalendarItem.astro
@@ -3,6 +3,7 @@ import { formatDate, getYear } from "date-fns";
 import { RichText } from "@/components/RichText";
 import { Sponsor } from "@/components/Sponsor";
 import { MatchResult } from "@/components/MatchResult";
+import { Scorecard } from "@/components/Scorecard";
 import { Map } from "@/components/Map";
 import { When } from "./When";
 import { AddToCalendarButton } from "add-to-calendar-button-react";
@@ -93,6 +94,11 @@ const { id, title, calendarItem } = Astro.props;
             ourTeamId={game.team.id}
             when={game.when ? game.when.toISOString() : null}
             ssrResult={game.result}
+          />
+          <Scorecard
+            client:load
+            matchId={id}
+            when={game.when ? game.when.toISOString() : null}
           />
           <RichText
             client:load

--- a/src/components/Scorecard.tsx
+++ b/src/components/Scorecard.tsx
@@ -1,0 +1,431 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/Card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/Table";
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQuery,
+} from "@tanstack/react-query";
+import { actions } from "astro:actions";
+import { isPast } from "date-fns";
+
+type BattingEntry = {
+  position: number;
+  name: string;
+  id: string;
+  howOut: string;
+  fielderName: string;
+  bowlerName: string;
+  runs: number;
+  balls: number;
+  fours: number;
+  sixes: number;
+};
+
+type BowlingEntry = {
+  name: string;
+  id: string;
+  overs: string;
+  maidens: number;
+  runs: number;
+  wickets: number;
+  wides: number;
+  noBalls: number;
+};
+
+type FoWEntry = {
+  wicketNumber: number;
+  runs: number;
+  batsmanOutName: string;
+};
+
+type Extras = {
+  byes: number;
+  legByes: number;
+  wides: number;
+  noBalls: number;
+  penalties: number;
+  total: number;
+};
+
+type InningsTotal = {
+  runs: number;
+  wickets: number;
+  overs: string;
+  declared: boolean;
+};
+
+type ScorecardInnings = {
+  teamBattingName: string;
+  teamBattingId: string;
+  inningsNumber: number;
+  batting: BattingEntry[];
+  bowling: BowlingEntry[];
+  fallOfWickets: FoWEntry[];
+  extras: Extras;
+  total: InningsTotal;
+};
+
+type MatchDetailData = {
+  homeTeamName: string;
+  homeTeamId: string;
+  awayTeamName: string;
+  awayTeamId: string;
+  toss: string;
+  result: string;
+  resultDescription: string;
+  resultAppliedTo: string;
+  battedFirst: string;
+  innings: ScorecardInnings[];
+};
+
+function formatDismissal(entry: BattingEntry): string {
+  const { howOut, fielderName, bowlerName } = entry;
+  switch (howOut) {
+    case "b":
+      return `b ${bowlerName}`;
+    case "ct":
+      return fielderName && fielderName === bowlerName
+        ? `c & b ${bowlerName}`
+        : `c ${fielderName} b ${bowlerName}`;
+    case "lbw":
+      return `lbw b ${bowlerName}`;
+    case "ro":
+      return fielderName ? `run out (${fielderName})` : "run out";
+    case "st":
+      return `st ${fielderName} b ${bowlerName}`;
+    case "hw":
+      return `hit wicket b ${bowlerName}`;
+    case "no":
+      return "not out";
+    case "rtd":
+      return "retired";
+    case "dnb":
+      return "did not bat";
+    default:
+      return howOut || "unknown";
+  }
+}
+
+function formatExtrasBreakdown(extras: Extras): string {
+  const parts: string[] = [];
+  if (extras.byes) parts.push(`b ${extras.byes}`);
+  if (extras.legByes) parts.push(`lb ${extras.legByes}`);
+  if (extras.wides) parts.push(`w ${extras.wides}`);
+  if (extras.noBalls) parts.push(`nb ${extras.noBalls}`);
+  if (extras.penalties) parts.push(`pen ${extras.penalties}`);
+  return parts.join(", ");
+}
+
+function formatTotalScore(total: InningsTotal): string {
+  const wicketsPart = total.wickets >= 10 ? "" : `/${total.wickets}`;
+  const declaredPart = total.declared ? " dec" : "";
+  const oversPart = total.overs ? ` (${total.overs} ov)` : "";
+  return `${total.runs}${wicketsPart}${declaredPart}${oversPart}`;
+}
+
+function oversToDecimal(overs: string): number {
+  const parts = overs.split(".");
+  const completedOvers = parseInt(parts[0], 10) || 0;
+  const balls = parts.length > 1 ? parseInt(parts[1], 10) || 0 : 0;
+  return completedOvers + balls / 6;
+}
+
+function buildResultText(data: MatchDetailData): string {
+  if (!data.result) return "";
+  if (data.result === "D") return "Match drawn";
+  if (data.result === "T") return "Match tied";
+
+  const desc = data.resultDescription.toLowerCase();
+  if (desc.includes("abandon")) return "Match abandoned";
+  if (desc.includes("cancel")) return "Match cancelled";
+  if (desc.includes("no result")) return "No result";
+
+  if (
+    data.result === "W" &&
+    data.resultAppliedTo &&
+    data.innings.length >= 2
+  ) {
+    const winningTeamId = data.resultAppliedTo;
+    const winningTeamName =
+      winningTeamId === data.homeTeamId
+        ? data.homeTeamName
+        : data.awayTeamName;
+
+    const secondInnings = data.innings[1];
+
+    if (secondInnings.teamBattingId === winningTeamId) {
+      const wicketsInHand = 10 - secondInnings.total.wickets;
+      return `${winningTeamName} won by ${wicketsInHand} wicket${wicketsInHand !== 1 ? "s" : ""}`;
+    } else {
+      const firstInnings = data.innings[0];
+      const margin = firstInnings.total.runs - secondInnings.total.runs;
+      return `${winningTeamName} won by ${margin} run${margin !== 1 ? "s" : ""}`;
+    }
+  }
+
+  return data.resultDescription;
+}
+
+function BattingCard({
+  batting,
+  extras,
+  total,
+}: {
+  batting: BattingEntry[];
+  extras: Extras;
+  total: InningsTotal;
+}) {
+  const activeBatters = batting.filter((b) => b.howOut !== "dnb");
+  const didNotBat = batting.filter((b) => b.howOut === "dnb");
+
+  return (
+    <div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-full">Batter</TableHead>
+            <TableHead className="text-right">R</TableHead>
+            <TableHead className="text-right">B</TableHead>
+            <TableHead className="text-right">4s</TableHead>
+            <TableHead className="text-right">6s</TableHead>
+            <TableHead className="text-right">SR</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {activeBatters.map((b) => (
+            <TableRow key={b.position}>
+              <TableCell>
+                <div>
+                  <span className="font-medium">{b.name}</span>
+                  <div className="text-xs text-gray-500">
+                    {formatDismissal(b)}
+                  </div>
+                </div>
+              </TableCell>
+              <TableCell className="text-right font-mono font-semibold tabular-nums">
+                {b.runs}
+              </TableCell>
+              <TableCell className="text-right font-mono tabular-nums">
+                {b.balls || "-"}
+              </TableCell>
+              <TableCell className="text-right font-mono tabular-nums">
+                {b.fours}
+              </TableCell>
+              <TableCell className="text-right font-mono tabular-nums">
+                {b.sixes}
+              </TableCell>
+              <TableCell className="text-right font-mono tabular-nums">
+                {b.balls > 0
+                  ? ((b.runs / b.balls) * 100).toFixed(1)
+                  : "-"}
+              </TableCell>
+            </TableRow>
+          ))}
+          <TableRow>
+            <TableCell>
+              <span className="text-sm text-gray-600">
+                Extras ({formatExtrasBreakdown(extras)})
+              </span>
+            </TableCell>
+            <TableCell className="text-right font-mono font-semibold tabular-nums">
+              {extras.total}
+            </TableCell>
+            <TableCell colSpan={4} />
+          </TableRow>
+          <TableRow className="border-t-2 font-bold">
+            <TableCell>Total</TableCell>
+            <TableCell
+              className="text-right font-mono tabular-nums"
+              colSpan={5}
+            >
+              {formatTotalScore(total)}
+            </TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+      {didNotBat.length > 0 && (
+        <p className="mt-2 text-xs text-gray-500">
+          <strong>Did not bat:</strong>{" "}
+          {didNotBat.map((b) => b.name).join(", ")}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function BowlingCard({ bowling }: { bowling: BowlingEntry[] }) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-full">Bowler</TableHead>
+          <TableHead className="text-right">O</TableHead>
+          <TableHead className="text-right">M</TableHead>
+          <TableHead className="text-right">R</TableHead>
+          <TableHead className="text-right">W</TableHead>
+          <TableHead className="text-right">Econ</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {bowling.map((b, i) => {
+          const decimalOvers = oversToDecimal(b.overs);
+          const economy =
+            decimalOvers > 0 ? (b.runs / decimalOvers).toFixed(1) : "-";
+          return (
+            <TableRow key={`${b.id}-${i}`}>
+              <TableCell className="font-medium">{b.name}</TableCell>
+              <TableCell className="text-right font-mono tabular-nums">
+                {b.overs}
+              </TableCell>
+              <TableCell className="text-right font-mono tabular-nums">
+                {b.maidens}
+              </TableCell>
+              <TableCell className="text-right font-mono tabular-nums">
+                {b.runs}
+              </TableCell>
+              <TableCell className="text-right font-mono font-semibold tabular-nums">
+                {b.wickets}
+              </TableCell>
+              <TableCell className="text-right font-mono tabular-nums">
+                {economy}
+              </TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}
+
+function FallOfWickets({ fow }: { fow: FoWEntry[] }) {
+  if (fow.length === 0) return null;
+  return (
+    <p className="text-xs text-gray-600">
+      <strong>Fall of wickets:</strong>{" "}
+      {fow.map((f, i) => (
+        <span key={f.wicketNumber}>
+          {i > 0 && ", "}
+          {f.wicketNumber}-{f.runs} ({f.batsmanOutName})
+        </span>
+      ))}
+    </p>
+  );
+}
+
+function InningsCard({ innings }: { innings: ScorecardInnings }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-lg">{innings.teamBattingName}</CardTitle>
+        <div className="text-sm font-semibold text-gray-700">
+          {formatTotalScore(innings.total)}
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <BattingCard
+          batting={innings.batting}
+          extras={innings.extras}
+          total={innings.total}
+        />
+        <FallOfWickets fow={innings.fallOfWickets} />
+        <div className="border-t pt-4">
+          <h5 className="mb-2 text-sm font-semibold text-gray-700">Bowling</h5>
+          <BowlingCard bowling={innings.bowling} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ScorecardSkeleton() {
+  return (
+    <div className="flex flex-col gap-4">
+      <h4 className="text-h6 md:text-h4">Scorecard</h4>
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {[0, 1].map((i) => (
+          <Card key={i}>
+            <CardHeader>
+              <div className="h-5 w-40 animate-pulse rounded bg-gray-200" />
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {Array.from({ length: 6 }, (_, j) => (
+                <div
+                  key={j}
+                  className="h-4 animate-pulse rounded bg-gray-100"
+                />
+              ))}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ScorecardDisplay({ data }: { data: MatchDetailData }) {
+  const resultText = buildResultText(data);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h4 className="text-h6 md:text-h4">Scorecard</h4>
+        {resultText && (
+          <span className="text-sm font-medium text-gray-600">
+            {resultText}
+          </span>
+        )}
+      </div>
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {data.innings.map((inn) => (
+          <InningsCard key={inn.inningsNumber} innings={inn} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+type ScorecardInnerProps = {
+  matchId: string;
+  when: string | null;
+};
+
+function ScorecardInner({ matchId, when }: ScorecardInnerProps) {
+  const gameInPast = when ? isPast(new Date(when)) : false;
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["getMatchDetail", matchId],
+    queryFn: () => actions.playCricket.getMatchDetail({ matchId }),
+    enabled: gameInPast,
+    staleTime: 30 * 60 * 1000,
+  });
+
+  if (!gameInPast) return null;
+  if (isLoading) return <ScorecardSkeleton />;
+
+  const matchDetail = data?.data;
+  if (!matchDetail || matchDetail.innings.length === 0) return null;
+
+  return <ScorecardDisplay data={matchDetail} />;
+}
+
+const queryClient = new QueryClient();
+
+type ScorecardProps = {
+  matchId: string;
+  when: string | null;
+};
+
+export function Scorecard(props: ScorecardProps) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ScorecardInner {...props} />
+    </QueryClientProvider>
+  );
+}

--- a/src/lib/play-cricket/index.ts
+++ b/src/lib/play-cricket/index.ts
@@ -197,3 +197,122 @@ export const getResultSummary = async ({
       throw new Error("Failed to parse result summary response");
     });
 };
+
+const MatchDetailBat = z.object({
+  position: z.string(),
+  batsman_name: z.string(),
+  batsman_id: z.string(),
+  how_out: z.string(),
+  fielder_name: z.string().optional().default(""),
+  fielder_id: z.string().optional().default(""),
+  bowler_name: z.string().optional().default(""),
+  bowler_id: z.string().optional().default(""),
+  runs: z.string(),
+  fours: z.string(),
+  sixes: z.string(),
+  balls: z.string(),
+});
+
+const MatchDetailBowl = z.object({
+  bowler_name: z.string(),
+  bowler_id: z.string(),
+  overs: z.string(),
+  maidens: z.string(),
+  runs: z.string(),
+  wides: z.string(),
+  wickets: z.string(),
+  no_balls: z.string(),
+});
+
+const MatchDetailFoW = z.object({
+  runs: z.string(),
+  wickets: z.number(),
+  batsman_out_name: z.string(),
+  batsman_out_id: z.string(),
+  batsman_in_name: z.string().optional().default(""),
+  batsman_in_id: z.string().optional().default(""),
+  batsman_in_runs: z.string().optional().default(""),
+});
+
+const MatchDetailInnings = z.object({
+  team_batting_name: z.string(),
+  team_batting_id: z.string(),
+  innings_number: z.number(),
+  extra_byes: z.string(),
+  extra_leg_byes: z.string(),
+  extra_wides: z.string(),
+  extra_no_balls: z.string(),
+  extra_penalty_runs: z.string(),
+  penalties_runs_awarded_in_other_innings: z.string(),
+  total_extras: z.string(),
+  runs: z.string(),
+  wickets: z.string(),
+  overs: z.string(),
+  declared: z.boolean(),
+  revised_target_runs: z.string(),
+  revised_target_overs: z.string(),
+  bat: z.array(MatchDetailBat),
+  bowl: z.array(MatchDetailBowl),
+  fow: z.array(MatchDetailFoW),
+});
+
+const MatchDetailPlayer = z.object({
+  position: z.number(),
+  player_name: z.string(),
+  player_id: z.number(),
+  captain: z.boolean(),
+  wicket_keeper: z.boolean(),
+});
+
+const MatchDetail = z.object({
+  id: z.number(),
+  home_team_name: z.string(),
+  home_team_id: z.string(),
+  home_club_name: z.string(),
+  home_club_id: z.string().optional().default(""),
+  away_team_name: z.string(),
+  away_team_id: z.string(),
+  away_club_name: z.string(),
+  away_club_id: z.string().optional().default(""),
+  toss: z.string().optional().default(""),
+  batted_first: z.string().optional().default(""),
+  result: z.string().optional().default(""),
+  result_description: z.string().optional().default(""),
+  result_applied_to: z.string().optional().default(""),
+  players: z.array(
+    z.object({
+      home_team: z.array(MatchDetailPlayer).optional(),
+      away_team: z.array(MatchDetailPlayer).optional(),
+    }),
+  ),
+  innings: z.array(MatchDetailInnings),
+});
+
+const GetMatchDetailResponse = z.object({
+  match_details: z.array(MatchDetail),
+});
+
+export const getMatchDetail = async ({
+  matchId,
+}: {
+  matchId: string;
+}): Promise<z.TypeOf<typeof GetMatchDetailResponse>> => {
+  const params = new URLSearchParams({
+    match_id: matchId,
+    api_token: PLAY_CRICKET_API_KEY,
+  });
+  const res = await fetch(
+    `http://play-cricket.com/api/v2/match_detail.json?${params}`,
+  );
+
+  return await res
+    .json()
+    .then((data) => GetMatchDetailResponse.parse(data))
+    .catch((err) => {
+      console.error(
+        "Error parsing match detail response:",
+        JSON.stringify(err, null, 2),
+      );
+      throw new Error("Failed to parse match detail response");
+    });
+};


### PR DESCRIPTION
## Summary
- Adds full match scorecards to game detail pages by fetching data from the Play-Cricket Match Detail API
- Displays batting card (with dismissal descriptions, strike rates), bowling figures (with economy rates), fall of wickets, and extras breakdown
- Innings shown side by side on desktop (`lg:grid-cols-2`), stacked on mobile
- Builds descriptive result text (e.g. "Team A won by 7 wickets") from innings data
- React island with `useQuery` and 30-min `staleTime` — scorecards are immutable once complete
- Loading skeleton shown while fetching; hidden for future fixtures

### Files changed
- `src/lib/play-cricket/index.ts` — added `getMatchDetail()` with Zod schemas for batting, bowling, FoW, extras
- `src/actions/play-cricket.ts` — added `playCricket.getMatchDetail` action that transforms raw API data
- `src/components/Scorecard.tsx` — new React island with `BattingCard`, `BowlingCard`, `FallOfWickets`, `InningsCard` components
- `src/components/CalendarItem.astro` — integrated `Scorecard` island on game detail pages

## Test plan
- [ ] Navigate to a past game detail page and verify the scorecard loads with batting/bowling data
- [ ] Verify dismissal descriptions are correctly formatted (e.g. "c Smith b Jones", "lbw b Jones")
- [ ] Verify extras breakdown shows correctly (b, lb, w, nb)
- [ ] Verify the descriptive result text is accurate (e.g. "won by X wickets/runs")
- [ ] Check responsive layout: side by side on desktop, stacked on mobile
- [ ] Navigate to a future fixture and verify no scorecard appears
- [ ] Verify the loading skeleton displays briefly before data loads

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)