### PR TITLE
Seed deploy preview DBs from production database

### DIFF
--- a/scripts/netlify/migrate/index.js
+++ b/scripts/netlify/migrate/index.js
@@ -35,9 +35,9 @@ async function ensureBranchDatabase(branch) {
   const seedDb = process.env.TURSO_SEED_DB_NAME || parentDb;
   const group = process.env.TURSO_GROUP || "default";
 
-  if (!apiToken || !org || !parentDb) {
+  if (!apiToken || !org || !seedDb) {
     console.log(
-      "Turso branching env vars not configured (TURSO_API_TOKEN, TURSO_ORG, TURSO_DB_NAME) — using shared preview DB",
+      "Turso branching env vars not configured (TURSO_API_TOKEN, TURSO_ORG, TURSO_SEED_DB_NAME or TURSO_DB_NAME) — using shared preview DB",
     );
     return null;
   }
@@ -56,7 +56,10 @@ async function ensureBranchDatabase(branch) {
   if (checkRes.ok) {
     const data = await checkRes.json();
     const hostname = data.database?.Hostname || data.database?.hostname;
-    console.log(`Reusing existing branch database: ${hostname}`);
+    console.log(
+      `Reusing existing branch database: ${hostname}. ` +
+        `If seeded before TURSO_SEED_DB_NAME was configured, close and reopen the PR to reseed from production.`,
+    );
     return `libsql://${hostname}`;
   }
 


### PR DESCRIPTION
## Summary

- Adds `TURSO_SEED_DB_NAME` env var to the Netlify migration plugin to control which database is used as the seed when creating per-PR branch databases
- When set to the production database name, deploy previews get realistic data for testing features like player stats, leaderboards, and record linking
- Falls back to `TURSO_DB_NAME` (shared preview DB) for backward compatibility if the new var is not set

## Setup required

After merging, set `TURSO_SEED_DB_NAME` to the production Turso database name in Netlify's environment variables. Existing preview branch DBs will continue to work — only newly created branches will seed from production.

**Note:** Existing per-PR branch databases are reused if they already exist. To force a fresh seed from production for an existing PR, close and reopen the PR (which deletes and recreates the Turso branch DB).

## Test plan

- [ ] Verify `TURSO_SEED_DB_NAME` is set in Netlify env vars after merge
- [ ] Open a new PR and confirm the deploy preview branch DB is seeded from production (check build logs for `Creating branch database "..." seeded from "<prod-db-name>"`)
- [ ] Verify the deploy preview has realistic data (e.g. player profiles, leaderboards)

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)