### PR TITLE
Fix preview DB cleanup to use correct database name

### DIFF
--- a/.github/workflows/cleanup-preview-db.yml
+++ b/.github/workflows/cleanup-preview-db.yml
@@ -17,17 +17,11 @@ jobs:
           TURSO_API_TOKEN: ${{ secrets.TURSO_API_TOKEN }}
           TURSO_ORG: percymain
         run: |
-          BRANCH="${{ github.head_ref }}"
-
-          # Sanitise to match the naming convention in the Netlify build plugin
-          SANITIZED=$(echo "$BRANCH" \
-            | tr '[:upper:]' '[:lower:]' \
-            | sed 's/[^a-z0-9-]/-/g' \
-            | sed 's/-\+/-/g' \
-            | sed 's/^-\|-$//g' \
-            | cut -c1-46)
-
-          DB_NAME="preview-${SANITIZED}"
+          # Netlify sets BRANCH to "pull/<number>/head" for deploy previews,
+          # which the migrate plugin sanitises to "pull-<number>-head".
+          # Use the PR number directly to match that convention.
+          PR_NUMBER="${{ github.event.number }}"
+          DB_NAME="preview-pull-${PR_NUMBER}-head"
 
           echo "Deleting preview database: ${DB_NAME}"
 


### PR DESCRIPTION
## Summary

- Preview database cleanup has been silently failing since it was introduced — every delete returns 404
- **Root cause:** Netlify sets `BRANCH` to `pull/<number>/head` for deploy previews, so the migrate plugin creates databases named `preview-pull-<number>-head` (e.g. `preview-pull-110-head`). But the cleanup workflow was using `github.head_ref` (the git branch name like `166-player-profile-stats-enhancements`), producing a completely different name that never matched.
- **Fix:** Use `github.event.number` (the PR number) to construct the correct database name directly

## Test plan

- [ ] Merge this PR and verify the cleanup workflow deletes `preview-pull-172-head` (check the workflow logs for HTTP 200 instead of 404)
- [ ] On next PR merge, confirm the Turso database is actually removed from the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)