### PR TITLE
feat: cricket leaderboard exposure

### DIFF
--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -100,7 +100,6 @@ const renderOptions = (page: string, games: Game[]): Options => ({
             discipline={fields.discipline ?? "both"}
             category={fields.category ?? "seniors"}
             limit={fields.limit ?? 10}
-            profileMap={new Map()}
           />
         );
       } else if (contentTypeId === "assetLink") {

--- a/src/lib/cricket-season.ts
+++ b/src/lib/cricket-season.ts
@@ -6,35 +6,3 @@ export function currentCricketSeason(): number {
   const now = new Date();
   return now.getMonth() < 3 ? now.getFullYear() - 1 : now.getFullYear();
 }
-
-/**
- * Fetch leaderboard data with automatic season fallback.
- * If the target season has no data, falls back to the previous season.
- */
-export async function fetchWithSeasonFallback<
-  T extends { entries: unknown[] },
->(
-  fetcher: (season: number) => Promise<{ data?: T; error?: unknown }>,
-  season: number,
-): Promise<{ data: T; season: number }> {
-  const result = await fetcher(season);
-  if (result.error) {
-    throw result.error instanceof Error
-      ? result.error
-      : new Error("Leaderboard fetch failed");
-  }
-  if (result.data && result.data.entries.length > 0) {
-    return { data: result.data, season };
-  }
-  // Fall back to previous season
-  const fallback = await fetcher(season - 1);
-  if (fallback.error) {
-    throw fallback.error instanceof Error
-      ? fallback.error
-      : new Error("Leaderboard fallback fetch failed");
-  }
-  if (!fallback.data) {
-    return { data: { entries: [] } as unknown as T, season: season - 1 };
-  }
-  return { data: fallback.data, season: season - 1 };
-}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -89,10 +89,9 @@ const donateUrl = `/purchase/${paymentData.prices.donation}`;
     )
   }
 
-  <!-- 2b. Season Leaders -->
+  <!-- 2b. Season Leaders (heading rendered inside React component, hidden when no data) -->
   <section class="bg-primary/5 py-10">
     <div class="container">
-      <h3 class="text-h4 mb-6 text-center">Season Leaders</h3>
       <SeasonLeaders client:load personProfiles={personProfiles} />
     </div>
   </section>


### PR DESCRIPTION
## Summary

- Adds **Season Leaders** widget to the homepage between "What's Coming Up Soon" and "Latest News" — shows top 3 batting (by runs) and top 3 bowling (by wickets) with player profile links
- Adds **LeaderboardEmbed** component for Contentful CMS pages — follows the same pattern as the existing `LeagueTable` embed, wired into `RichText.tsx` for the `cricketLeaderboard` content type
- **Smart season fallback**: both widgets automatically show the previous season's stats when the current season has no data yet (e.g. off-season), then seamlessly switch when the first match is recorded
- Shared `cricket-season.ts` utility with `currentCricketSeason()` and `fetchWithSeasonFallback()`

### Contentful setup needed
After merge, create a `cricketLeaderboard` content type in Contentful with fields:
- `title` (Symbol)
- `season` (Integer, optional)
- `discipline` (Symbol — batting/bowling/both)
- `category` (Symbol — seniors/juniors)
- `limit` (Integer, optional)

Then embed it on the `/cricket` page or any rich text content.

## Test plan
- [ ] Verify homepage shows Season Leaders section with 2025 data (since 2026 season hasn't started)
- [ ] Verify "View full leaderboard" link points to correct season
- [ ] Verify player names link to their profile pages
- [ ] Verify the widget renders nothing gracefully if no data exists at all
- [ ] After Contentful type is created, test embedding a leaderboard widget in a CMS page

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)