### PR TITLE
feat: sync all historical play cricket data (2000-2025)

### DIFF
--- a/netlify/functions/do-sync-play-cricket-background.mts
+++ b/netlify/functions/do-sync-play-cricket-background.mts
@@ -33,8 +33,10 @@ export const handler: Handler = async (event) => {
       siteId,
       dbUrl,
       dbToken,
-      // TODO: remove 2025 after first successful sync
-      extraSeasons: [2025],
+      // Temporarily sync all historical seasons (2000-2025) for all-time leaderboards.
+      // Current year (2026) is automatically included by runSync.
+      // Revert to [] after historical sync completes successfully.
+      extraSeasons: Array.from({ length: 26 }, (_, i) => 2000 + i),
     });
 
     return {


### PR DESCRIPTION
## Summary
- Expands `extraSeasons` to cover 2000-2025 (26 seasons) for all-time leaderboard generation
- Current year (2026) is automatically included by `runSync`
- Uses existing sequential match processing with upserts — safe for re-runs

## Process
1. Merge this PR and deploy
2. Trigger the sync via the cron function endpoint (or wait for scheduled run)
3. Monitor `play_cricket_sync_log` table for completion
4. After successful sync, open a follow-up PR to revert `extraSeasons` back to `[]`

## Risks
- **Timeout**: 15-minute Netlify background function limit. If there are many matches with scorecards, it could timeout. Sequential API calls (~0.5-1s each). If it times out, it can be re-triggered — upserts mean no duplicate data.
- **Rate limiting**: No explicit delay between Play-Cricket API calls. If rate-limited, individual match errors are caught and logged without stopping the sync.

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)