### PR TITLE
Show sponsor logos on homepage upcoming games

### DIFF
--- a/src/components/CalendarStripCard.astro
+++ b/src/components/CalendarStripCard.astro
@@ -1,6 +1,7 @@
 ---
 import { formatDate } from "date-fns";
 import type { CalendarItem } from "@/collections/calendarItem";
+import { GameCardSponsor } from "@/components/GameCardSponsor";
 
 type Props = {
   id: string;
@@ -16,6 +17,10 @@ const displayName =
     : item.name;
 const dateStr = item.when ? formatDate(item.when, "EEE dd MMM") : "TBC";
 const timeStr = item.when ? formatDate(item.when, "h:mm a") : "";
+const ssrSponsor =
+  item.type === "game" && item.sponsor
+    ? { name: item.sponsor.name, logoUrl: item.sponsor.logoUrl }
+    : undefined;
 ---
 
 <a
@@ -54,23 +59,12 @@ const timeStr = item.when ? formatDate(item.when, "h:mm a") : "";
   <p class="text-sm font-medium text-dark line-clamp-2">{displayName}</p>
   {timeStr && <p class="mt-1 text-xs text-gray-500">{timeStr}</p>}
   {
-    item.type === "game" && item.sponsor && (
-      <div class="mt-auto flex items-center gap-1.5 border-t border-gray-100 pt-2">
-        {item.sponsor.logoUrl ? (
-          <img
-            src={item.sponsor.logoUrl}
-            alt={`Sponsored by ${item.sponsor.name}`}
-            width="60"
-            height="24"
-            class="h-6 max-w-[60px] object-contain"
-          />
-        ) : (
-          <span class="min-w-0 text-[10px] font-medium text-gray-500 leading-tight truncate">
-            {item.sponsor.name}
-          </span>
-        )}
-        <span class="text-[10px] text-gray-400 leading-tight shrink-0">Sponsored</span>
-      </div>
+    item.type === "game" && (
+      <GameCardSponsor
+        client:load
+        gameId={id}
+        ssrSponsor={ssrSponsor}
+      />
     )
   }
 </a>

--- a/src/components/GameCardSponsor.tsx
+++ b/src/components/GameCardSponsor.tsx
@@ -1,0 +1,65 @@
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQuery,
+} from "@tanstack/react-query";
+import { actions } from "astro:actions";
+
+type SponsorData = {
+  name: string;
+  logoUrl?: string;
+};
+
+type Props = {
+  gameId: string;
+  ssrSponsor?: SponsorData;
+};
+
+const queryClient = new QueryClient();
+
+function GameCardSponsorInner({ gameId, ssrSponsor }: Props) {
+  const { data } = useQuery({
+    queryKey: ["game-sponsor", gameId],
+    queryFn: async () => {
+      const result = await actions.sponsorship.getByGameId({ gameId });
+      if (result.error) throw result.error;
+      return result.data;
+    },
+    initialData: ssrSponsor ? { sponsor: ssrSponsor } : undefined,
+    initialDataUpdatedAt: ssrSponsor ? 0 : undefined,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const sponsor = data?.sponsor ?? ssrSponsor;
+
+  if (!sponsor) return null;
+
+  return (
+    <div className="mt-auto flex items-center gap-1.5 border-t border-gray-100 pt-2">
+      {sponsor.logoUrl ? (
+        <img
+          src={sponsor.logoUrl}
+          alt={`Sponsored by ${sponsor.name}`}
+          width="60"
+          height="24"
+          className="h-6 max-w-[60px] object-contain"
+        />
+      ) : (
+        <span className="min-w-0 truncate text-[10px] font-medium leading-tight text-gray-500">
+          {sponsor.name}
+        </span>
+      )}
+      <span className="shrink-0 text-[10px] leading-tight text-gray-400">
+        Sponsored
+      </span>
+    </div>
+  );
+}
+
+export function GameCardSponsor(props: Props) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <GameCardSponsorInner {...props} />
+    </QueryClientProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- Display sponsor logo (or name fallback) on the "What's Coming Up Soon" game cards on the homepage
- Shows a small logo (`h-6`, max 60px wide) with a "Sponsored" label, separated by a subtle border
- When a sponsor has no logo, falls back to displaying the sponsor's name as text
- Only renders for games with an approved, paid sponsor

Closes #188

## Test plan
- [ ] Verify a sponsored game with a logo shows the logo at the bottom of the card
- [ ] Verify a sponsored game without a logo shows the sponsor name text
- [ ] Verify unsponsored games and events do not show any sponsor section
- [ ] Check card alignment in the horizontal strip when some cards have sponsors and some don't

🤖 Generated with [Claude Code](https://claude.com/claude-code)