### PR TITLE
fix: add .mdx extensions to internal doc links

### DIFF
--- a/docs/admin/README.mdx
+++ b/docs/admin/README.mdx
@@ -6,7 +6,7 @@ This guide covers everything you need to know about administering the Percy Main
 
 This documentation is for club members with the <RoleBadge role="admin" /> role. Admins have full access to manage members, payments, sponsorships, and site content.
 
-There is also a <RoleBadge role="junior-manager" /> role for people who manage junior teams — see [Junior Managers](junior-managers) for details.
+There is also a <RoleBadge role="junior-manager" /> role for people who manage junior teams — see [Junior Managers](junior-managers.mdx) for details.
 
 ## Accessing the Admin Panel
 
@@ -20,18 +20,18 @@ The admin panel is organised into seven tabs:
 
 | Tab | Purpose | Guide |
 |-----|---------|-------|
-| **Members** | Browse and manage user accounts | [Members](members) |
-| **Juniors** | View all junior players with team grouping | [Juniors](juniors) |
-| **Charges** | Monitor payments and send reminders | [Charges](charges) |
-| **Contact Submissions** | Read messages from the contact form | [Contact Submissions](contact-submissions) |
-| **Sponsorships** | Approve and manage game sponsorships | [Sponsorships](sponsorships) |
-| **Duplicates** | Find and merge duplicate member records | [Duplicate Members](duplicate-members) |
-| **Record Linking** | Link members to Play-Cricket and Contentful | [Record Linking](record-linking) |
+| **Members** | Browse and manage user accounts | [Members](members.mdx) |
+| **Juniors** | View all junior players with team grouping | [Juniors](juniors.mdx) |
+| **Charges** | Monitor payments and send reminders | [Charges](charges.mdx) |
+| **Contact Submissions** | Read messages from the contact form | [Contact Submissions](contact-submissions.mdx) |
+| **Sponsorships** | Approve and manage game sponsorships | [Sponsorships](sponsorships.mdx) |
+| **Duplicates** | Find and merge duplicate member records | [Duplicate Members](duplicate-members.mdx) |
+| **Record Linking** | Link members to Play-Cricket and Contentful | [Record Linking](record-linking.mdx) |
 
 ## Content Management
 
-The website content (news articles, pages, events, people profiles) is managed in **Contentful**, a separate CMS. See [Contentful CMS](contentful-cms) for how to use it.
+The website content (news articles, pages, events, people profiles) is managed in **Contentful**, a separate CMS. See [Contentful CMS](contentful-cms.mdx) for how to use it.
 
 ## Reporting Bugs
 
-Found something broken? See [Bug Reporting](bug-reporting) for how to report issues.
+Found something broken? See [Bug Reporting](bug-reporting.mdx) for how to report issues.

--- a/docs/admin/members.mdx
+++ b/docs/admin/members.mdx
@@ -44,7 +44,7 @@ You can promote a regular user to admin or demote an admin to a regular user:
 3. The role change takes effect immediately
 
 <Callout type="info">
-The Promote/Demote button only toggles between the <RoleBadge role="user" /> and <RoleBadge role="admin" /> roles. To assign the <RoleBadge role="junior-manager" /> role, use the **Junior Manager** section lower in the same modal — see [Junior Managers](junior-managers).
+The Promote/Demote button only toggles between the <RoleBadge role="user" /> and <RoleBadge role="admin" /> roles. To assign the <RoleBadge role="junior-manager" /> role, use the **Junior Manager** section lower in the same modal — see [Junior Managers](junior-managers.mdx).
 </Callout>
 
 <Callout type="warning">


### PR DESCRIPTION
## Summary

- Doxla's `resolveDocLink` only recognises links ending in `.md`/`.mdx` — bare names like `(members)` fall through and become broken relative URLs instead of hash routes
- Added `.mdx` extensions to all 12 internal links in `README.mdx` and `members.mdx`

This is a workaround for a doxla bug (its own docs use extensionless links too).

## Test plan

- [ ] Verify links on the docs site work after deploy (e.g. `#/doc/docs/admin/members` instead of `/web/members`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)