### PR TITLE
feat: seed test admin user on deploy previews

### DIFF
--- a/scripts/netlify/migrate/index.js
+++ b/scripts/netlify/migrate/index.js
@@ -181,7 +181,7 @@ async function hashPasswordForBetterAuth(password) {
   const { bytesToHex } = await import("@noble/hashes/utils.js");
   const { randomBytes } = await import("node:crypto");
 
-  const salt = randomBytes(16).toString("hex");
+  const salt = bytesToHex(randomBytes(16));
   const key = await scryptAsync(password.normalize("NFKC"), salt, {
     N: 16384,
     r: 16,
@@ -252,7 +252,7 @@ async function seedPreviewAdmin(url, authToken) {
       })
       .execute();
 
-    console.log(`Preview admin seeded — email: ${email}, password: ${password}`);
+    console.log(`Preview admin seeded — email: ${email}`);
   } finally {
     await db.destroy();
   }


### PR DESCRIPTION
## Summary
- Adds a `seedPreviewAdmin` function to the Netlify migrate build plugin that inserts a test admin user into deploy preview branch databases after migrations complete
- Uses better-auth's scrypt password format (`@noble/hashes` — already a transitive dep) so the user can log in normally
- Credentials default to `admin@preview.percymain.org` / `PreviewAdmin123!`, configurable via `PREVIEW_ADMIN_EMAIL` / `PREVIEW_ADMIN_PASSWORD` env vars
- Idempotent (skips if user already exists) and non-fatal (errors logged but don't fail the build)

## Test plan
- [ ] Open this PR and wait for the deploy preview to build
- [ ] Check the Netlify build logs for "Preview admin seeded" message
- [ ] Navigate to the deploy preview admin login page
- [ ] Log in with `admin@preview.percymain.org` / `PreviewAdmin123!`
- [ ] Verify admin panel access works

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)