### PR TITLE
Add sponsor benefits text and upfront pricing to checkout

### DIFF
--- a/src/actions/player-sponsorship.ts
+++ b/src/actions/player-sponsorship.ts
@@ -3,36 +3,23 @@ import { currentCricketSeason } from "@/lib/cricket-season";
 import { client } from "@/lib/db/client";
 import { stripe } from "@/lib/payments/client";
 import { paymentData } from "@/lib/payments/config";
+import { getStripePrice } from "@/lib/payments/getStripePrice";
 import { resolveStripeCustomer } from "@/lib/payments/resolveStripeCustomer";
 import { ActionError, defineAction } from "astro:actions";
 import { CONTEXT } from "astro:env/client";
 import { DEPLOY_PRIME_URL } from "astro:env/server";
 import { z } from "astro:schema";
 import { randomUUID } from "crypto";
-import type Stripe from "stripe";
 
 const MAX_LOGO_SIZE_BYTES = 150_000;
 
 export const playerSponsorship = {
   getPrice: defineAction({
     handler: async () => {
-      const priceId = paymentData.prices.playerSponsorship;
-      const price = await stripe.prices.retrieve(priceId, {
-        expand: ["product"],
-      });
-      const product = price.product as Stripe.Product;
-      const amount = price.unit_amount;
-      if (!amount) {
-        throw new ActionError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "Player sponsorship price not configured",
-        });
-      }
-      return {
-        amountPence: amount,
-        currency: price.currency,
-        productName: product.name,
-      };
+      const { amount, currency, productName } = await getStripePrice(
+        paymentData.prices.playerSponsorship,
+      );
+      return { amountPence: amount, currency, productName };
     },
   }),
 
@@ -86,20 +73,9 @@ export const playerSponsorship = {
           });
         }
 
-        const priceId = paymentData.prices.playerSponsorship;
-        const price = await stripe.prices.retrieve(priceId, {
-          expand: ["product"],
-        });
-
-        const product = price.product as Stripe.Product;
-        const amount = price.unit_amount;
-
-        if (!amount) {
-          throw new ActionError({
-            code: "INTERNAL_SERVER_ERROR",
-            message: "Player sponsorship price not configured",
-          });
-        }
+        const { amount, currency, productName } = await getStripePrice(
+          paymentData.prices.playerSponsorship,
+        );
 
         const sponsorshipId = randomUUID();
 
@@ -133,7 +109,7 @@ export const playerSponsorship = {
 
         const paymentIntent = await stripe.paymentIntents.create({
           amount,
-          currency: price.currency,
+          currency,
           automatic_payment_methods: { enabled: true },
           ...(customerId ? { customer: customerId } : {}),
           metadata: enrichedMetadata,
@@ -155,7 +131,7 @@ export const playerSponsorship = {
         return {
           clientSecret: paymentIntent.client_secret,
           amount,
-          productName: product.name,
+          productName,
         };
       } catch (err) {
         if (err instanceof ActionError) throw err;

--- a/src/components/PlayerSponsorCheckout.tsx
+++ b/src/components/PlayerSponsorCheckout.tsx
@@ -16,6 +16,7 @@ import {
   useQuery,
 } from "@tanstack/react-query";
 import { actions } from "astro:actions";
+import { formatPrice } from "@/lib/formatPrice";
 import { type ChangeEvent, type FC, useCallback, useState } from "react";
 import { PaymentForm } from "./PaymentForm";
 
@@ -169,10 +170,6 @@ const PlayerSponsorCheckoutInner: FC<Props> = ({
     staleTime: 5 * 60 * 1000,
   });
 
-  const formatPrice = (amountPence: number) => {
-    return `\u00A3${(amountPence / 100).toFixed(amountPence % 100 === 0 ? 0 : 2)}`;
-  };
-
   const isFormValid =
     sponsorName.trim().length > 0 &&
     sponsorEmail.trim().length > 0 &&
@@ -237,6 +234,16 @@ const PlayerSponsorCheckoutInner: FC<Props> = ({
         </p>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
+        {priceQuery.isPending && (
+          <p className="text-sm text-gray-500">Loading price...</p>
+        )}
+        {priceQuery.isError && (
+          <Alert variant="destructive">
+            <AlertDescription>
+              Could not load pricing. Please refresh and try again.
+            </AlertDescription>
+          </Alert>
+        )}
         {priceQuery.data && (
           <div className="rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-900">
             <strong>Price:</strong> {formatPrice(priceQuery.data.amountPence)}

--- a/src/lib/formatPrice.ts
+++ b/src/lib/formatPrice.ts
@@ -1,0 +1,3 @@
+export function formatPrice(amountPence: number): string {
+  return `\u00A3${(amountPence / 100).toFixed(amountPence % 100 === 0 ? 0 : 2)}`;
+}

--- a/src/lib/payments/getStripePrice.ts
+++ b/src/lib/payments/getStripePrice.ts
@@ -1,0 +1,18 @@
+import { stripe } from "@/lib/payments/client";
+import { ActionError } from "astro:actions";
+import type Stripe from "stripe";
+
+export async function getStripePrice(priceId: string) {
+  const price = await stripe.prices.retrieve(priceId, {
+    expand: ["product"],
+  });
+  const product = price.product as Stripe.Product;
+  const amount = price.unit_amount;
+  if (!amount) {
+    throw new ActionError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Price not configured",
+    });
+  }
+  return { amount, currency: price.currency, productName: product.name };
+}


### PR DESCRIPTION
## Summary
- Adds benefits description with link to `/cricket/become-a-sponsor/` on both game and player sponsorship checkout pages
- Shows the current Stripe price in a highlighted section **before form fields** (not just on the Pay button)
- Game sponsorship checkout now has a description (previously had none — just the game title)
- New `getPrice` actions on both `sponsorship` and `playerSponsorship` modules to fetch price without creating a payment

## Screenshots
Changes are to React islands that require Stripe configuration — see deploy preview for live testing.

## Test plan
- [ ] Game sponsorship checkout: verify benefits text, link, and price display
- [ ] Player sponsorship checkout: verify benefits text, link, and price display
- [ ] Link to `/cricket/become-a-sponsor/` works from both pages
- [ ] Price loads and displays correctly (formatted as £XX)

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)