### PR TITLE
Move listJuniors filtering server-side with pagination

### DIFF
--- a/src/actions/admin.tsx
+++ b/src/actions/admin.tsx
@@ -545,7 +545,7 @@ export const admin = {
     roles: ["admin"],
     input: z.object({
       page: z.number().int().min(1),
-      pageSize: z.number().int().min(1).max(200),
+      pageSize: z.number().int().min(1).max(100),
       search: z.string().optional(),
       sex: z.enum(["all", "male", "female"]).default("all"),
       ageGroup: z.enum(["all", ...AGE_GROUPS]).default("all"),

--- a/src/components/admin/JuniorsTable.tsx
+++ b/src/components/admin/JuniorsTable.tsx
@@ -62,6 +62,7 @@ export function JuniorsTable() {
     }
     debounceTimerRef.current = setTimeout(() => {
       setDebouncedSearch(search);
+      setPage(1);
     }, 300);
     return () => {
       if (debounceTimerRef.current) {
@@ -69,11 +70,6 @@ export function JuniorsTable() {
       }
     };
   }, [search]);
-
-  // Reset to page 1 when filters change
-  useEffect(() => {
-    setPage(1);
-  }, [debouncedSearch, ageGroupFilter, sexFilter, membershipFilter]);
 
   const { data, isLoading, error } = useQuery({
     queryKey: [
@@ -144,9 +140,10 @@ export function JuniorsTable() {
         />
         <select
           value={ageGroupFilter}
-          onChange={(e) =>
-            setAgeGroupFilter(e.target.value as AgeGroup | "all")
-          }
+          onChange={(e) => {
+            setAgeGroupFilter(e.target.value as AgeGroup | "all");
+            setPage(1);
+          }}
           className="rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
         >
           <option value="all">All Age Groups</option>
@@ -158,7 +155,10 @@ export function JuniorsTable() {
         </select>
         <select
           value={sexFilter}
-          onChange={(e) => setSexFilter(e.target.value as SexFilter)}
+          onChange={(e) => {
+            setSexFilter(e.target.value as SexFilter);
+            setPage(1);
+          }}
           className="rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
         >
           <option value="all">All Genders</option>
@@ -167,9 +167,10 @@ export function JuniorsTable() {
         </select>
         <select
           value={membershipFilter}
-          onChange={(e) =>
-            setMembershipFilter(e.target.value as MembershipFilter)
-          }
+          onChange={(e) => {
+            setMembershipFilter(e.target.value as MembershipFilter);
+            setPage(1);
+          }}
           className="rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
         >
           <option value="all">All Memberships</option>


### PR DESCRIPTION
## Summary
- Adds typed input schema to `listJuniors` action: `page`, `pageSize`, `search`, `sex`, `ageGroup`, `membershipStatus`
- Applies `sex` and `search` filters at the SQL query level for efficiency
- Applies `ageGroup` and `membershipStatus` as post-query filters (these are computed from `dob`/`paidUntil` and can't be expressed in SQL)
- Adds server-side pagination (LIMIT/OFFSET + total count)
- Updates `JuniorsTable.tsx` to pass all filters in `queryKey`/`queryFn`, removing the client-side `useMemo` filtering logic
- Adds pagination controls and auto-resets to page 1 when filters change

## Why
- Consistency with `listUsers` and `listAllCharges` patterns
- Better scalability as junior membership grows (pre-season registration imminent)
- Avoids downloading the full dataset on every mount

## Test plan
- [ ] Admin juniors page loads with paginated results
- [ ] Search filters work (by junior name and parent name)
- [ ] Sex filter narrows results server-side
- [ ] Age group and membership status filters work
- [ ] Pagination controls appear and function correctly
- [ ] Page resets to 1 when changing filters

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)