### PR TITLE
Optimize leaderboard queries: fewer round-trips, server-side limits

### DIFF
--- a/src/components/LeaderboardEmbed.tsx
+++ b/src/components/LeaderboardEmbed.tsx
@@ -128,11 +128,12 @@ function LeaderboardEmbedInner({
   >(showBatting ? "batting" : "bowling");
 
   const battingQuery = useQuery({
-    queryKey: ["leaderboard-embed-batting", targetSeason, isJunior],
+    queryKey: ["leaderboard-embed-batting", targetSeason, isJunior, limit],
     queryFn: async () => {
       const primary = await actions.playCricket.getBattingLeaderboard({
         season: targetSeason,
         isJunior,
+        limit,
       });
       if (primary.error) throw primary.error;
       if (primary.data && primary.data.entries.length > 0) {
@@ -141,6 +142,7 @@ function LeaderboardEmbedInner({
       const fallback = await actions.playCricket.getBattingLeaderboard({
         season: targetSeason - 1,
         isJunior,
+        limit,
       });
       if (fallback.error) throw fallback.error;
       return { data: fallback.data, season: targetSeason - 1 };
@@ -150,11 +152,12 @@ function LeaderboardEmbedInner({
   });
 
   const bowlingQuery = useQuery({
-    queryKey: ["leaderboard-embed-bowling", targetSeason, isJunior],
+    queryKey: ["leaderboard-embed-bowling", targetSeason, isJunior, limit],
     queryFn: async () => {
       const primary = await actions.playCricket.getBowlingLeaderboard({
         season: targetSeason,
         isJunior,
+        limit,
       });
       if (primary.error) throw primary.error;
       if (primary.data && primary.data.entries.length > 0) {
@@ -163,6 +166,7 @@ function LeaderboardEmbedInner({
       const fallback = await actions.playCricket.getBowlingLeaderboard({
         season: targetSeason - 1,
         isJunior,
+        limit,
       });
       if (fallback.error) throw fallback.error;
       return { data: fallback.data, season: targetSeason - 1 };
@@ -178,14 +182,8 @@ function LeaderboardEmbedInner({
 
   if (hasError) return null;
 
-  const battingEntries = (battingQuery.data?.data?.entries ?? []).slice(
-    0,
-    limit,
-  );
-  const bowlingEntries = (bowlingQuery.data?.data?.entries ?? []).slice(
-    0,
-    limit,
-  );
+  const battingEntries = battingQuery.data?.data?.entries ?? [];
+  const bowlingEntries = bowlingQuery.data?.data?.entries ?? [];
 
   const effectiveSeason =
     battingQuery.data?.season ?? bowlingQuery.data?.season ?? targetSeason;

--- a/src/components/SeasonLeaders.tsx
+++ b/src/components/SeasonLeaders.tsx
@@ -117,6 +117,7 @@ function SeasonLeadersInner({
       const primary = await actions.playCricket.getBattingLeaderboard({
         season,
         isJunior: false,
+        limit: 3,
       });
       if (primary.error) throw primary.error;
       if (primary.data && primary.data.entries.length > 0) {
@@ -125,6 +126,7 @@ function SeasonLeadersInner({
       const fallback = await actions.playCricket.getBattingLeaderboard({
         season: season - 1,
         isJunior: false,
+        limit: 3,
       });
       if (fallback.error) throw fallback.error;
       return { data: fallback.data, season: season - 1 };
@@ -138,6 +140,7 @@ function SeasonLeadersInner({
       const primary = await actions.playCricket.getBowlingLeaderboard({
         season,
         isJunior: false,
+        limit: 3,
       });
       if (primary.error) throw primary.error;
       if (primary.data && primary.data.entries.length > 0) {
@@ -146,6 +149,7 @@ function SeasonLeadersInner({
       const fallback = await actions.playCricket.getBowlingLeaderboard({
         season: season - 1,
         isJunior: false,
+        limit: 3,
       });
       if (fallback.error) throw fallback.error;
       return { data: fallback.data, season: season - 1 };
@@ -158,8 +162,8 @@ function SeasonLeadersInner({
 
   if (hasError) return null;
 
-  const battingEntries = (battingQuery.data?.data?.entries ?? []).slice(0, 3);
-  const bowlingEntries = (bowlingQuery.data?.data?.entries ?? []).slice(0, 3);
+  const battingEntries = battingQuery.data?.data?.entries ?? [];
+  const bowlingEntries = bowlingQuery.data?.data?.entries ?? [];
 
   const effectiveSeason =
     battingQuery.data?.season ?? bowlingQuery.data?.season ?? season;

--- a/src/lib/db/migrations/2026-02-27T18:15:42.837Z.ts
+++ b/src/lib/db/migrations/2026-02-27T18:15:42.837Z.ts
@@ -1,0 +1,18 @@
+import type { Kysely } from "kysely";
+import { sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Replace the non-unique index with a unique one.
+  // play_cricket_id should be unique per member (nullable, but unique when set).
+  await sql`DROP INDEX IF EXISTS idx_member_play_cricket_id`.execute(db);
+  await sql`CREATE UNIQUE INDEX idx_member_play_cricket_id ON member(play_cricket_id) WHERE play_cricket_id IS NOT NULL`.execute(
+    db,
+  );
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_member_play_cricket_id`.execute(db);
+  await sql`CREATE INDEX idx_member_play_cricket_id ON member(play_cricket_id)`.execute(
+    db,
+  );
+}


### PR DESCRIPTION
## Summary

- **Batting leaderboard**: 2 DB queries → 1 (subquery for GROUP BY + LIMIT, then LEFT JOIN member for contentful IDs)
- **Bowling leaderboard**: 3 DB queries → 1 (overs-to-balls conversion moved into SQL `SUM(CASE...)`, member joined after GROUP BY)
- **Server-side `limit` param**: callers now request only what they display — homepage passes `limit: 3` instead of fetching 50 rows and slicing client-side
- **Unique index on `member.play_cricket_id`**: partial unique index (WHERE NOT NULL) since each member maps to at most one Play Cricket ID

## Impact

| Scenario | Before (Turso round-trips) | After |
|----------|---------------------------|-------|
| Homepage (top 3) | 5 (2 batting + 3 bowling) | 2 |
| Full leaderboard | 5 | 2 |
| Embed widget | 5 | 2 |

Rows returned also reduced: homepage was fetching 50×2 then slicing to 3×2, now fetches 3×2.

## Test plan

- [ ] Homepage season leaders widget loads correctly with top 3 batting/bowling
- [ ] Full leaderboard page (`/leaderboard/2025`) shows all 50 entries with correct stats
- [ ] Leaderboard embed renders correct number of entries matching its `limit` prop
- [ ] Bowling overs display correctly (e.g. "45.3" not "273 balls")
- [ ] Player profile links still resolve from contentful entry IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)