### PR TITLE
Fix duplicate calendar entries from date grouping

### DIFF
--- a/src/components/calendar/CalendarAgenda.tsx
+++ b/src/components/calendar/CalendarAgenda.tsx
@@ -556,19 +556,21 @@ export function CalendarAgenda({
     return items.filter((item) => item.category === activeFilter);
   }, [items, activeFilter]);
 
-  // Group by date
+  // Group by date (using a Map to merge items on the same day regardless of sort order)
   const grouped = useMemo(() => {
-    const groups: Array<{ dateStr: string; items: CalendarItem[] }> = [];
+    const map = new Map<string, CalendarItem[]>();
     for (const item of filteredItems) {
       const dateStr = item.when.split("T")[0];
-      const last = groups[groups.length - 1];
-      if (last && last.dateStr === dateStr) {
-        last.items.push(item);
+      const existing = map.get(dateStr);
+      if (existing) {
+        existing.push(item);
       } else {
-        groups.push({ dateStr, items: [item] });
+        map.set(dateStr, [item]);
       }
     }
-    return groups;
+    return [...map.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([dateStr, items]) => ({ dateStr, items }));
   }, [filteredItems]);
 
   // Find divider position: between last past and first future


### PR DESCRIPTION
## Summary
- The calendar agenda's sequential date grouping assumed items were sorted strictly by date, but the Astro build sorts events before games on the same day
- When an event on date X appeared before games on date X-1 in the sorted array, the sequential walk created two separate groups for date X, causing duplicate rendering
- Switched to Map-based grouping that collects all items per date first, then sorts the groups

Fixes the duplicate "Refugee Week Celebration" event on the June 2025 calendar page.

## Test plan
- [ ] Verify `/calendar/2025/june/?team=event` shows only one Refugee Week Celebration card
- [ ] Verify `/calendar/2025/june/` shows the event once in the full agenda
- [ ] Verify other months still render correctly (May 2025 results, Feb 2026 empty state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)