### PR TITLE
Fix leaderboard hydration error by extracting shared schemas

### DIFF
--- a/src/lib/leaderboard-client.ts
+++ b/src/lib/leaderboard-client.ts
@@ -1,11 +1,9 @@
 import {
   BattingResponseSchema,
-  type BattingResponse,
-} from "@/pages/api/leaderboard/batting";
-import {
   BowlingResponseSchema,
+  type BattingResponse,
   type BowlingResponse,
-} from "@/pages/api/leaderboard/bowling";
+} from "@/lib/leaderboard-schemas";
 
 type LeaderboardParams = {
   season: number;

--- a/src/lib/leaderboard-schemas.ts
+++ b/src/lib/leaderboard-schemas.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+// Batting schemas
+export const BattingEntrySchema = z.object({
+  playerId: z.string(),
+  playerName: z.string(),
+  contentfulEntryId: z.string().nullable(),
+  innings: z.number(),
+  notOuts: z.number(),
+  runs: z.number(),
+  highScore: z.number(),
+  average: z.number().nullable(),
+  strikeRate: z.number().nullable(),
+  fours: z.number(),
+  sixes: z.number(),
+  fifties: z.number(),
+  hundreds: z.number(),
+});
+
+export const BattingResponseSchema = z.object({
+  entries: z.array(BattingEntrySchema),
+});
+
+export type BattingEntry = z.infer<typeof BattingEntrySchema>;
+export type BattingResponse = z.infer<typeof BattingResponseSchema>;
+
+// Bowling schemas
+export const BowlingEntrySchema = z.object({
+  playerId: z.string(),
+  playerName: z.string(),
+  contentfulEntryId: z.string().nullable(),
+  matches: z.number(),
+  overs: z.string(),
+  maidens: z.number(),
+  runs: z.number(),
+  wickets: z.number(),
+  average: z.number().nullable(),
+  economy: z.number().nullable(),
+  strikeRate: z.number().nullable(),
+  bestWickets: z.number(),
+});
+
+export const BowlingResponseSchema = z.object({
+  entries: z.array(BowlingEntrySchema),
+});
+
+export type BowlingEntry = z.infer<typeof BowlingEntrySchema>;
+export type BowlingResponse = z.infer<typeof BowlingResponseSchema>;

--- a/src/pages/api/leaderboard/batting.ts
+++ b/src/pages/api/leaderboard/batting.ts
@@ -1,36 +1,13 @@
 export const prerender = false;
 
 import { client } from "@/lib/db/client";
+import type { BattingEntry } from "@/lib/leaderboard-schemas";
 import type { APIContext } from "astro";
 import { sql } from "kysely";
-import { z } from "zod";
 
 const MAX_LIMIT = 50;
 const CACHE_MAX_AGE = 43200; // 12 hours
 const CACHE_SWR = 86400; // 24 hours stale-while-revalidate
-
-export const BattingEntrySchema = z.object({
-  playerId: z.string(),
-  playerName: z.string(),
-  contentfulEntryId: z.string().nullable(),
-  innings: z.number(),
-  notOuts: z.number(),
-  runs: z.number(),
-  highScore: z.number(),
-  average: z.number().nullable(),
-  strikeRate: z.number().nullable(),
-  fours: z.number(),
-  sixes: z.number(),
-  fifties: z.number(),
-  hundreds: z.number(),
-});
-
-export const BattingResponseSchema = z.object({
-  entries: z.array(BattingEntrySchema),
-});
-
-export type BattingEntry = z.infer<typeof BattingEntrySchema>;
-export type BattingResponse = z.infer<typeof BattingResponseSchema>;
 
 export async function GET({ url }: APIContext): Promise<Response> {
   const season = Number(url.searchParams.get("season"));

--- a/src/pages/api/leaderboard/bowling.ts
+++ b/src/pages/api/leaderboard/bowling.ts
@@ -1,35 +1,13 @@
 export const prerender = false;
 
 import { client } from "@/lib/db/client";
+import type { BowlingEntry } from "@/lib/leaderboard-schemas";
 import type { APIContext } from "astro";
 import { sql } from "kysely";
-import { z } from "zod";
 
 const MAX_LIMIT = 50;
 const CACHE_MAX_AGE = 43200; // 12 hours
 const CACHE_SWR = 86400; // 24 hours stale-while-revalidate
-
-export const BowlingEntrySchema = z.object({
-  playerId: z.string(),
-  playerName: z.string(),
-  contentfulEntryId: z.string().nullable(),
-  matches: z.number(),
-  overs: z.string(),
-  maidens: z.number(),
-  runs: z.number(),
-  wickets: z.number(),
-  average: z.number().nullable(),
-  economy: z.number().nullable(),
-  strikeRate: z.number().nullable(),
-  bestWickets: z.number(),
-});
-
-export const BowlingResponseSchema = z.object({
-  entries: z.array(BowlingEntrySchema),
-});
-
-export type BowlingEntry = z.infer<typeof BowlingEntrySchema>;
-export type BowlingResponse = z.infer<typeof BowlingResponseSchema>;
 
 export async function GET({ url }: APIContext): Promise<Response> {
   const season = Number(url.searchParams.get("season"));


### PR DESCRIPTION
## Summary
- Extracted batting and bowling zod schemas from API route files into a new shared `src/lib/leaderboard-schemas.ts` file
- Updated `src/lib/leaderboard-client.ts` to import schemas from the shared file instead of from API routes
- Updated API routes (`batting.ts`, `bowling.ts`) to import types from the shared file

## Problem
The leaderboard client imported zod schemas directly from the server-side API route files. Those routes import `{ client } from "@/lib/db/client"` at the top level, which creates a `LibsqlDialect` instance. When Vite bundled for the browser, it followed the full import chain and the `LibsqlDialect` constructor threw because DB env vars don't exist on the client:

```
Error: Please specify either `client` or `url` in the LibsqlDialect config
```

## Fix
The new shared file (`src/lib/leaderboard-schemas.ts`) only imports `zod` — no server-side dependencies. Both the API routes and the client-side leaderboard fetch module import from this shared file, breaking the problematic import chain.

## Test plan
- [x] `npm run build` passes without errors
- [ ] Deploy preview loads leaderboard pages without console errors
- [ ] Leaderboard data displays correctly on batting and bowling tabs

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)