### PR TITLE
Add filtering to admin members table

### DIFF
--- a/src/actions/admin.tsx
+++ b/src/actions/admin.tsx
@@ -31,7 +31,7 @@ export const admin = {
       membershipStatus: z.enum(["all", "active", "expired", "none"]).default("all"),
       membershipType: z.enum(["all", "senior_player", "senior_women_player", "social", "junior", "concessionary"]).default("all"),
       memberCategory: z.union([z.literal("all"), memberCategorySchema]).default("all"),
-      role: z.enum(["all", "user", "admin", "junior_manager"]).default("all"),
+      role: z.enum(["all", "user", "admin", "official", "junior_manager"]).default("all"),
     }),
     handler: async ({ page, pageSize, search, includeArchived, isMember, membershipStatus, membershipType, memberCategory, role }) => {
       function applyFilters(

--- a/src/components/admin/MemberTable.tsx
+++ b/src/components/admin/MemberTable.tsx
@@ -27,7 +27,7 @@ type MemberFilter = "all" | "yes" | "no";
 type MembershipStatusFilter = "all" | "active" | "expired" | "none";
 type MembershipTypeFilter = "all" | "senior_player" | "senior_women_player" | "social" | "junior" | "concessionary";
 type MemberCategoryFilter = "all" | "senior" | "junior" | "student" | "bursary" | "guest";
-type RoleFilter = "all" | "user" | "admin" | "junior_manager";
+type RoleFilter = "all" | "user" | "admin" | "official" | "junior_manager";
 
 const PAGE_SIZE = 20;
 
@@ -160,6 +160,7 @@ export function MemberTable() {
               <SelectItem value="all">All Roles</SelectItem>
               <SelectItem value="user">User</SelectItem>
               <SelectItem value="admin">Admin</SelectItem>
+              <SelectItem value="official">Official</SelectItem>
               <SelectItem value="junior_manager">Junior Manager</SelectItem>
             </SelectContent>
           </Select>


### PR DESCRIPTION
## Summary
- Adds server-side filtering to the admin members table with 5 filter dimensions: member status, membership status, membership type, member category, and role
- Filter params are added to the `listUsers` action so pagination reflects filtered results correctly
- Uses shadcn Select components matching the existing pattern in JuniorsTable and ChargesTable
- Includes a "Clear filters" button when any filter is active

Closes #239

## Test plan
- [ ] Navigate to admin panel → Members tab
- [ ] Verify all 5 filter dropdowns appear below the search bar
- [ ] Test each filter independently (e.g. Member = "Member" shows only members)
- [ ] Test combining multiple filters (e.g. Active + Senior Player)
- [ ] Verify pagination updates to reflect filtered count
- [ ] Verify "Clear filters" button appears when filters are active and resets all
- [ ] Verify search still works alongside filters
- [ ] Verify "Show archived" checkbox still works alongside filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)