### PR TITLE
Tune fantasy scoring from 2025 season analysis

### DIFF
--- a/src/lib/fantasy/__tests__/scoring.test.ts
+++ b/src/lib/fantasy/__tests__/scoring.test.ts
@@ -14,6 +14,7 @@ describe("calculateBattingPoints", () => {
       fours: 0,
       sixes: 0,
       notOut: false,
+      battingPosition: 3,
     });
     expect(result.runs).toBe(35);
   });
@@ -25,6 +26,7 @@ describe("calculateBattingPoints", () => {
       fours: 4,
       sixes: 2,
       notOut: false,
+      battingPosition: 4,
     });
     expect(result.fours).toBe(4);
     expect(result.sixes).toBe(4);
@@ -37,6 +39,7 @@ describe("calculateBattingPoints", () => {
       fours: 5,
       sixes: 1,
       notOut: false,
+      battingPosition: 1,
     });
     expect(result.fiftyBonus).toBe(20);
     expect(result.hundredBonus).toBe(0);
@@ -49,21 +52,61 @@ describe("calculateBattingPoints", () => {
       fours: 10,
       sixes: 3,
       notOut: false,
+      battingPosition: 3,
     });
     expect(result.fiftyBonus).toBe(0);
     expect(result.hundredBonus).toBe(50);
   });
 
-  it("applies duck penalty for 0 runs when out", () => {
+  it("applies duck penalty for 0 runs when out at position 1-7", () => {
     const result = calculateBattingPoints({
       runs: 0,
       balls: 3,
       fours: 0,
       sixes: 0,
       notOut: false,
+      battingPosition: 5,
     });
     expect(result.duckPenalty).toBe(-10);
     expect(result.total).toBe(-10);
+  });
+
+  it("does not apply duck penalty for position 8+", () => {
+    const result = calculateBattingPoints({
+      runs: 0,
+      balls: 3,
+      fours: 0,
+      sixes: 0,
+      notOut: false,
+      battingPosition: 8,
+    });
+    expect(result.duckPenalty).toBe(0);
+    expect(result.total).toBe(0);
+  });
+
+  it("does not apply duck penalty for position 11", () => {
+    const result = calculateBattingPoints({
+      runs: 0,
+      balls: 1,
+      fours: 0,
+      sixes: 0,
+      notOut: false,
+      battingPosition: 11,
+    });
+    expect(result.duckPenalty).toBe(0);
+    expect(result.total).toBe(0);
+  });
+
+  it("applies duck penalty at position 7 boundary", () => {
+    const result = calculateBattingPoints({
+      runs: 0,
+      balls: 5,
+      fours: 0,
+      sixes: 0,
+      notOut: false,
+      battingPosition: 7,
+    });
+    expect(result.duckPenalty).toBe(-10);
   });
 
   it("does not apply duck penalty when not out on 0", () => {
@@ -73,6 +116,7 @@ describe("calculateBattingPoints", () => {
       fours: 0,
       sixes: 0,
       notOut: true,
+      battingPosition: 1,
     });
     expect(result.duckPenalty).toBe(0);
     expect(result.total).toBe(0);
@@ -86,20 +130,21 @@ describe("calculateBattingPoints", () => {
       fours: 6,
       sixes: 2,
       notOut: false,
+      battingPosition: 3,
     });
     expect(result.total).toBe(80);
   });
 });
 
 describe("calculateBowlingPoints", () => {
-  it("awards 25 points per wicket", () => {
+  it("awards 10 points per wicket", () => {
     const result = calculateBowlingPoints({
       overs: "10",
       maidens: 0,
       runs: 40,
       wickets: 2,
     });
-    expect(result.wickets).toBe(50);
+    expect(result.wickets).toBe(20);
   });
 
   it("awards 10 points per maiden", () => {
@@ -134,7 +179,7 @@ describe("calculateBowlingPoints", () => {
     expect(result.fiveWicketBonus).toBe(30);
   });
 
-  it("awards economy bonus for rate <= 4.0 with enough overs", () => {
+  it("awards economy bonus for rate < 4.0 with enough overs", () => {
     const result = calculateBowlingPoints({
       overs: "10",
       maidens: 2,
@@ -145,15 +190,37 @@ describe("calculateBowlingPoints", () => {
     expect(result.economyBonus).toBe(10);
   });
 
-  it("applies economy penalty for rate >= 8.0", () => {
+  it("does not award economy bonus for rate exactly 4.0", () => {
+    const result = calculateBowlingPoints({
+      overs: "10",
+      maidens: 0,
+      runs: 40,
+      wickets: 0,
+    });
+    // Economy = 40/10 = 4.0, not strictly less than threshold
+    expect(result.economyBonus).toBe(0);
+  });
+
+  it("applies economy penalty for rate > 7.0", () => {
     const result = calculateBowlingPoints({
       overs: "5",
       maidens: 0,
       runs: 50,
       wickets: 0,
     });
-    // Economy = 50/5 = 10.0, above 8.0 threshold
+    // Economy = 50/5 = 10.0, above 7.0 threshold
     expect(result.economyBonus).toBe(-10);
+  });
+
+  it("does not apply economy penalty for rate exactly 7.0", () => {
+    const result = calculateBowlingPoints({
+      overs: "5",
+      maidens: 0,
+      runs: 35,
+      wickets: 0,
+    });
+    // Economy = 35/5 = 7.0, not strictly greater than threshold
+    expect(result.economyBonus).toBe(0);
   });
 
   it("does not apply economy bonus/penalty with fewer than 3 overs", () => {
@@ -235,20 +302,20 @@ describe("calculateFieldingPoints", () => {
 describe("calculateMatchPoints", () => {
   it("combines all disciplines and win bonus", () => {
     const result = calculateMatchPoints(
-      { runs: 50, balls: 60, fours: 5, sixes: 1, notOut: false },
+      { runs: 50, balls: 60, fours: 5, sixes: 1, notOut: false, battingPosition: 3 },
       { overs: "8", maidens: 1, runs: 30, wickets: 2 },
       { catches: 1, runOuts: 0, stumpings: 0, isWicketkeeper: false },
       { teamWon: true },
     );
     // Batting: 50 + 5 + 2 + 20 = 77
-    // Bowling: 50 + 10 + 0 + 0 + 10 (econ 3.75) = 70
+    // Bowling: 20 + 10 + 0 + 0 + 10 (econ 3.75) = 40
     // Fielding: 10
     // Win bonus: 10
     expect(result.batting?.total).toBe(77);
-    expect(result.bowling?.total).toBe(70);
+    expect(result.bowling?.total).toBe(40);
     expect(result.fielding?.total).toBe(10);
     expect(result.winBonus).toBe(10);
-    expect(result.total).toBe(167);
+    expect(result.total).toBe(137);
   });
 
   it("handles null disciplines", () => {
@@ -267,7 +334,7 @@ describe("calculateMatchPoints", () => {
 
   it("awards no win bonus for a loss", () => {
     const result = calculateMatchPoints(
-      { runs: 10, balls: 15, fours: 1, sixes: 0, notOut: false },
+      { runs: 10, balls: 15, fours: 1, sixes: 0, notOut: false, battingPosition: 6 },
       null,
       null,
       { teamWon: false },

--- a/src/lib/fantasy/scoring.ts
+++ b/src/lib/fantasy/scoring.ts
@@ -4,8 +4,8 @@
  * Static config for point values, plus a calculation function that takes
  * a player's match performance and returns a points breakdown.
  *
- * Initial values are calibrated to be broadly equitable between batters and
- * bowlers. Ship and iterate based on early gameweek feedback.
+ * Values tuned against 2025 season data to balance batters, bowlers, and
+ * all-rounders. See PR for analysis details.
  */
 
 // ---------------------------------------------------------------------------
@@ -24,24 +24,26 @@ export const SCORING = {
     fiftyBonus: 20,
     /** Bonus for reaching 100 runs */
     hundredBonus: 50,
-    /** Penalty for a duck (0 runs, not-out excluded) */
+    /** Penalty for a duck (0 runs, not-out excluded). Only applies to positions 1–7. */
     duckPenalty: -10,
+    /** Batting positions eligible for duck penalty (1-based). Positions 8+ are not penalised. */
+    duckPenaltyMaxPosition: 7,
   },
   bowling: {
     /** Points per wicket taken */
-    perWicket: 25,
+    perWicket: 10,
     /** Points per maiden over bowled */
     perMaiden: 10,
     /** Bonus for taking 3 wickets in an innings */
     threeWicketBonus: 15,
     /** Bonus for taking 5 wickets in an innings */
     fiveWicketBonus: 30,
-    /** Economy bonus: awarded if economy rate <= this threshold */
+    /** Economy bonus: awarded if economy rate < this threshold */
     economyBonusThreshold: 4.0,
     /** Points awarded for good economy */
     economyBonus: 10,
-    /** Economy penalty: applied if economy rate >= this threshold */
-    economyPenaltyThreshold: 8.0,
+    /** Economy penalty: applied if economy rate > this threshold */
+    economyPenaltyThreshold: 7.0,
     /** Points deducted for poor economy */
     economyPenalty: -10,
     /** Minimum overs bowled to qualify for economy bonus/penalty */
@@ -83,7 +85,6 @@ export const SCORING = {
  * Update this set when new competition types are encountered.
  */
 export const LEAGUE_COMPETITION_TYPES = new Set([
-  "Division",
   "League",
 ]);
 
@@ -95,7 +96,8 @@ export const LEAGUE_COMPETITION_TYPES = new Set([
  * Run: SELECT id, name FROM play_cricket_team WHERE is_junior = 0
  */
 export const ELIGIBLE_TEAM_IDS = new Set<string>([
-  // Populate with actual 1st XI and 2nd XI team IDs after inspecting data
+  "68498", // 1st XI
+  "71066", // 2nd XI
 ]);
 
 // ---------------------------------------------------------------------------
@@ -108,6 +110,8 @@ export interface BattingInput {
   fours: number;
   sixes: number;
   notOut: boolean;
+  /** 1-based batting position in the order. Used for duck penalty eligibility. */
+  battingPosition: number;
 }
 
 export interface BowlingInput {
@@ -192,7 +196,9 @@ export function calculateBattingPoints(
   const fiftyBonus = input.runs >= 50 && input.runs < 100 ? s.fiftyBonus : 0;
   const hundredBonus = input.runs >= 100 ? s.hundredBonus : 0;
   const duckPenalty =
-    input.runs === 0 && !input.notOut ? s.duckPenalty : 0;
+    input.runs === 0 && !input.notOut && input.battingPosition <= s.duckPenaltyMaxPosition
+      ? s.duckPenalty
+      : 0;
 
   const total = runs + fours + sixes + fiftyBonus + hundredBonus + duckPenalty;
 
@@ -213,9 +219,9 @@ export function calculateBowlingPoints(
   let economyBonus = 0;
   if (oversDecimal >= s.economyMinOvers) {
     const economyRate = input.runs / oversDecimal;
-    if (economyRate <= s.economyBonusThreshold) {
+    if (economyRate < s.economyBonusThreshold) {
       economyBonus = s.economyBonus;
-    } else if (economyRate >= s.economyPenaltyThreshold) {
+    } else if (economyRate > s.economyPenaltyThreshold) {
       economyBonus = s.economyPenalty;
     }
   }


### PR DESCRIPTION
## Summary

Scoring parameters tuned by simulating against the full 2025 season prod data (1st + 2nd XI league matches). Key changes:

- **Wicket points reduced from 25 → 10**: All-rounders (especially Mashal at 1710pts) were dominating too heavily via bowling. A 3-for was worth 90pts minimum vs ~65 for a fifty — now rebalanced.
- **Duck penalty limited to positions 1–7**: 58% of ducks (74/126) were from positions 8+. Tail-enders like Robson had -58 batting points total — unfair for players who mainly bowl.
- **Economy thresholds tightened**: Bonus now requires strict <4 RPO (was ≤4), penalty triggers at >7 RPO (was ≥8). This moves penalty from 9% → 14% of qualifying spells.
- **Config populated**: `ELIGIBLE_TEAM_IDS` set to 1st XI (68498) and 2nd XI (71066). Removed unused `"Division"` from `LEAGUE_COMPETITION_TYPES`.

### Before vs After (top 5)

| Rank | Player | v1 Total | v2 Total | Change |
|------|--------|----------|----------|--------|
| 1 | Akakhel Mashal | 1710 | 1305 | -24% |
| 2 | Alex Young | 1139 | 814 | -29% |
| 3 | Steven Knight | 802 | 772 | -4% |
| 4 | Patrick Rathbone | 825 | 730 | -12% |
| 5 | Oliver Robson | 777 | 547 | -30% |

Pure batters held steady while bowling-heavy scores compressed — better overall balance.

## Test plan

- [x] All 28 scoring unit tests pass (updated for new parameters)
- [ ] Verify leaderboard queries still work on deploy preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)