### PR TITLE
Fantasy: Improve team selection UX

### DIFF
--- a/src/components/fantasy/TeamSelector.tsx
+++ b/src/components/fantasy/TeamSelector.tsx
@@ -771,7 +771,7 @@ export function TeamSelector() {
                     {saveMutation.error?.message ?? "Failed to save team."}
                   </p>
                 )}
-                {!hasChanges && !saveMutation.isSuccess && canSave === false && slotsValid && budgetValid && captainValid && wkValid && (
+                {!hasChanges && !saveMutation.isSuccess && slotsValid && budgetValid && captainValid && wkValid && (
                   <p className="text-sm text-gray-500">No changes to save.</p>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- **Pure-move drag-and-drop**: Dragging a player between sections now only changes that player's slot type — no more confusing auto-swap of another player
- **Empty slot placeholders**: Each section shows droppable "Empty slot" rows for unfilled positions, making it clear where players are needed
- **Overflow highlighting**: When a section has too many players (e.g. 7 batters), excess players are highlighted in red with a red border and badge on the section
- **Validation messages**: Clear, actionable messages explain exactly what needs fixing before saving (e.g. "Batting has 7/6 — move 1 player out")

## Test plan
- [ ] Drag a player from batting to bowling — only that player should move, no other player swaps
- [ ] Verify overflow players (beyond the slot limit) show with red background
- [ ] Verify overfilled sections show red border and red count badge
- [ ] Verify empty slots show as dashed "Empty slot" rows
- [ ] Drag a player onto an empty slot — player should move to that section
- [ ] With invalid slot distribution (e.g. 7/3/1), verify save is blocked with warning message
- [ ] With valid 6/4/1 distribution, verify save works as before
- [ ] Verify same-section reorder still works (drag within batting)
- [ ] Verify captain constraint: moving captain to allrounder removes captaincy and assigns new captain

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)