### PR TITLE
chore(deps): bump devalue from 5.6.3 to 5.6.4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,13 +33,13 @@ importers:
         specifier: ^1.5.4
         version: 1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.4(a0b3cbc228025ff8a055092fdaed5be1))(better-call@1.3.2(zod@3.25.76))(nanostores@1.1.1)
       '@contentful/live-preview':
-        specifier: ^4.9.9
+        specifier: ^4.6.3
         version: 4.9.9(graphql@16.13.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@contentful/rich-text-html-renderer':
-        specifier: ^17.1.6
+        specifier: ^17.0.0
         version: 17.1.6
       '@contentful/rich-text-react-renderer':
-        specifier: ^16.1.6
+        specifier: ^16.0.1
         version: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@contentful/rich-text-types':
         specifier: ^17.2.5
@@ -60,7 +60,7 @@ importers:
         specifier: ^0.4.1
         version: 0.4.1(kysely@0.28.11)
       '@netlify/blobs':
-        specifier: ^10.7.1
+        specifier: ^10.7.0
         version: 10.7.1
       '@netlify/functions':
         specifier: ^5.1.2
@@ -81,7 +81,7 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-tabs':
-        specifier: ^1.1.13
+        specifier: ^1.1.2
         version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@react-email/components':
         specifier: ^0.0.36
@@ -90,22 +90,22 @@ importers:
         specifier: 1.0.4
         version: 1.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@stripe/react-stripe-js':
-        specifier: ^5.6.1
+        specifier: ^5.6.0
         version: 5.6.1(@stripe/stripe-js@5.10.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@stripe/stripe-js':
-        specifier: ^5.10.0
+        specifier: ^5.4.0
         version: 5.10.0
       '@tailwindcss/forms':
-        specifier: ^0.5.11
+        specifier: ^0.5.9
         version: 0.5.11(tailwindcss@4.2.1)
       '@tailwindcss/typography':
-        specifier: ^0.5.19
+        specifier: ^0.5.15
         version: 0.5.19(tailwindcss@4.2.1)
       '@tanstack/react-query':
-        specifier: ^5.90.21
+        specifier: ^5.64.1
         version: 5.90.21(react@19.2.4)
       '@vis.gl/react-google-maps':
-        specifier: ^1.7.1
+        specifier: ^1.5.0
         version: 1.7.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       add-to-calendar-button-react:
         specifier: ^2.13.8
@@ -114,7 +114,7 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       astro-breadcrumbs:
-        specifier: ^3.3.3
+        specifier: ^3.3.1
         version: 3.3.3(astro@6.0.2(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
       astro-font:
         specifier: ^0.1.81
@@ -129,10 +129,10 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       contentful:
-        specifier: ^11.10.5
+        specifier: ^11.3.4
         version: 11.10.5
       contentful-management:
-        specifier: ^11.74.0
+        specifier: ^11.40.3
         version: 11.74.0
       date-fns:
         specifier: ^4.1.0
@@ -162,43 +162,43 @@ importers:
         specifier: ^11.1.0
         version: 11.1.0
       postcss:
-        specifier: ^8.5.8
+        specifier: ^8.4.49
         version: 8.5.8
       react:
-        specifier: ^19.2.4
+        specifier: ^19.0.0
         version: 19.2.4
       react-dom:
-        specifier: ^19.2.4
+        specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
       react-icons:
-        specifier: ^5.6.0
+        specifier: ^5.4.0
         version: 5.6.0(react@19.2.4)
       react-qr-code:
-        specifier: ^2.0.18
+        specifier: ^2.0.15
         version: 2.0.18(react@19.2.4)
       recharts:
         specifier: ^3.8.0
         version: 3.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@16.13.1)(react@19.2.4)(redux@5.0.1)
       schema-dts:
-        specifier: ^1.1.5
+        specifier: ^1.1.2
         version: 1.1.5
       stripe:
-        specifier: ^17.7.0
+        specifier: ^17.5.0
         version: 17.7.0
       tailwind-merge:
-        specifier: ^3.5.0
+        specifier: ^3.0.1
         version: 3.5.0
       tailwindcss:
-        specifier: ^4.2.1
+        specifier: ^4.0.0
         version: 4.2.1
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.2.1)
       ts-pattern:
-        specifier: ^5.9.0
+        specifier: ^5.6.0
         version: 5.9.0
       zod:
-        specifier: ^3.25.76
+        specifier: ^3.25.0
         version: 3.25.76
     devDependencies:
       '@babel/preset-react':
@@ -211,16 +211,16 @@ importers:
         specifier: ^1.4.21
         version: 1.4.21(@better-fetch/fetch@1.1.21)(@electric-sql/pglite@0.3.15)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.11)(mongodb@7.1.0)(mysql2@3.15.3)(nanostores@1.1.1)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(postgres@3.4.7)(prisma@7.5.0(@types/react@19.2.14)(better-sqlite3@12.6.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@eslint/js':
-        specifier: ^9.39.4
+        specifier: ^9.19.0
         version: 9.39.4
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
       '@tailwindcss/postcss':
-        specifier: ^4.2.1
+        specifier: ^4.0.0
         version: 4.2.1
       '@tailwindcss/vite':
-        specifier: ^4.2.1
+        specifier: ^4.0.0
         version: 4.2.1(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@total-typescript/ts-reset':
         specifier: ^0.6.1
@@ -241,19 +241,19 @@ importers:
         specifier: ^0.0.33
         version: 0.0.33
       '@types/lodash':
-        specifier: ^4.17.24
+        specifier: ^4.17.13
         version: 4.17.24
       '@types/react':
-        specifier: ^19.2.14
+        specifier: ^19.0.2
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.3
+        specifier: ^19.0.2
         version: 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/parser':
-        specifier: ^8.57.0
+        specifier: ^8.22.0
         version: 8.57.0(eslint@8.57.1)(typescript@5.9.3)
       autoprefixer:
-        specifier: ^10.4.27
+        specifier: ^10.4.20
         version: 10.4.27(postcss@8.5.8)
       better-sqlite3:
         specifier: ^12.6.2
@@ -262,13 +262,13 @@ importers:
         specifier: 4.0.0-beta.3
         version: 4.0.0-beta.3(chokidar@5.0.0)(dotenv@17.3.1)(giget@2.0.0)(jiti@2.6.1)
       cf-content-types-generator:
-        specifier: ^2.16.1
+        specifier: ^2.15.5
         version: 2.16.1
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
       contentful-merge:
-        specifier: ^2.6.17
+        specifier: ^2.6.5
         version: 2.6.17(typescript@5.9.3)
       dotenv:
         specifier: ^17.3.1
@@ -277,7 +277,7 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
       dpdm:
-        specifier: ^3.15.1
+        specifier: ^3.14.0
         version: 3.15.1
       eslint:
         specifier: ^8.57.1
@@ -286,10 +286,10 @@ importers:
         specifier: ^17.1.0
         version: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint-plugin-n@16.6.2(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-astro:
-        specifier: ^1.6.0
+        specifier: ^1.3.1
         version: 1.6.0(eslint@8.57.1)
       eslint-plugin-import:
-        specifier: ^2.32.0
+        specifier: ^2.31.0
         version: 2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
@@ -301,7 +301,7 @@ importers:
         specifier: ^6.6.0
         version: 6.6.0(eslint@8.57.1)
       eslint-plugin-react-hooks:
-        specifier: ^5.2.0
+        specifier: ^5.1.0
         version: 5.2.0(eslint@8.57.1)
       json-patch:
         specifier: ^0.7.0
@@ -310,43 +310,43 @@ importers:
         specifier: ^0.20.0
         version: 0.20.0(@libsql/kysely-libsql@0.4.1(kysely@0.28.11))(better-sqlite3@12.6.2)(kysely@0.28.11)(mysql2@3.15.3)(pg@8.20.0)(typescript@5.9.3)
       prettier:
-        specifier: ^3.8.1
+        specifier: ^3.4.2
         version: 3.8.1
       prettier-plugin-astro:
         specifier: ^0.14.1
         version: 0.14.1
       prettier-plugin-organize-imports:
-        specifier: ^4.3.0
+        specifier: ^4.1.0
         version: 4.3.0(prettier@3.8.1)(typescript@5.9.3)
       prettier-plugin-tailwindcss:
-        specifier: ^0.6.14
+        specifier: ^0.6.11
         version: 0.6.14(prettier-plugin-astro@0.14.1)(prettier-plugin-organize-imports@4.3.0(prettier@3.8.1)(typescript@5.9.3))(prettier@3.8.1)
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
       react-compiler-runtime:
-        specifier: 19.0.0-beta-ebf51a3-20250411
+        specifier: ^19.0.0-beta-b2e8e9c-20241220
         version: 19.0.0-beta-ebf51a3-20250411(react@19.2.4)
       react-email:
         specifier: 3.0.6
         version: 3.0.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tsx:
-        specifier: ^4.21.0
+        specifier: ^4.19.2
         version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       typescript-eslint:
-        specifier: ^8.57.0
+        specifier: ^8.22.0
         version: 8.57.0(eslint@8.57.1)(typescript@5.9.3)
       vitest:
-        specifier: ^3.2.4
+        specifier: ^3.0.5
         version: 3.2.4(@types/debug@4.1.12)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
       yocto-spinner:
         specifier: ^1.1.0
         version: 1.1.0
       zx:
-        specifier: ^8.8.5
+        specifier: ^8.3.0
         version: 8.8.5
 
 packages:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,13 +33,13 @@ importers:
         specifier: ^1.5.4
         version: 1.5.4(@better-auth/core@1.5.4(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.4(a0b3cbc228025ff8a055092fdaed5be1))(better-call@1.3.2(zod@3.25.76))(nanostores@1.1.1)
       '@contentful/live-preview':
-        specifier: ^4.6.3
+        specifier: ^4.9.9
         version: 4.9.9(graphql@16.13.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@contentful/rich-text-html-renderer':
-        specifier: ^17.0.0
+        specifier: ^17.1.6
         version: 17.1.6
       '@contentful/rich-text-react-renderer':
-        specifier: ^16.0.1
+        specifier: ^16.1.6
         version: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@contentful/rich-text-types':
         specifier: ^17.2.5
@@ -60,7 +60,7 @@ importers:
         specifier: ^0.4.1
         version: 0.4.1(kysely@0.28.11)
       '@netlify/blobs':
-        specifier: ^10.7.0
+        specifier: ^10.7.1
         version: 10.7.1
       '@netlify/functions':
         specifier: ^5.1.2
@@ -81,7 +81,7 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-tabs':
-        specifier: ^1.1.2
+        specifier: ^1.1.13
         version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@react-email/components':
         specifier: ^0.0.36
@@ -90,22 +90,22 @@ importers:
         specifier: 1.0.4
         version: 1.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@stripe/react-stripe-js':
-        specifier: ^5.6.0
+        specifier: ^5.6.1
         version: 5.6.1(@stripe/stripe-js@5.10.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@stripe/stripe-js':
-        specifier: ^5.4.0
+        specifier: ^5.10.0
         version: 5.10.0
       '@tailwindcss/forms':
-        specifier: ^0.5.9
+        specifier: ^0.5.11
         version: 0.5.11(tailwindcss@4.2.1)
       '@tailwindcss/typography':
-        specifier: ^0.5.15
+        specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.2.1)
       '@tanstack/react-query':
-        specifier: ^5.64.1
+        specifier: ^5.90.21
         version: 5.90.21(react@19.2.4)
       '@vis.gl/react-google-maps':
-        specifier: ^1.5.0
+        specifier: ^1.7.1
         version: 1.7.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       add-to-calendar-button-react:
         specifier: ^2.13.8
@@ -114,7 +114,7 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       astro-breadcrumbs:
-        specifier: ^3.3.1
+        specifier: ^3.3.3
         version: 3.3.3(astro@6.0.2(@netlify/blobs@10.7.1)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
       astro-font:
         specifier: ^0.1.81
@@ -129,10 +129,10 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       contentful:
-        specifier: ^11.3.4
+        specifier: ^11.10.5
         version: 11.10.5
       contentful-management:
-        specifier: ^11.40.3
+        specifier: ^11.74.0
         version: 11.74.0
       date-fns:
         specifier: ^4.1.0
@@ -162,43 +162,43 @@ importers:
         specifier: ^11.1.0
         version: 11.1.0
       postcss:
-        specifier: ^8.4.49
+        specifier: ^8.5.8
         version: 8.5.8
       react:
-        specifier: ^19.0.0
+        specifier: ^19.2.4
         version: 19.2.4
       react-dom:
-        specifier: ^19.0.0
+        specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       react-icons:
-        specifier: ^5.4.0
+        specifier: ^5.6.0
         version: 5.6.0(react@19.2.4)
       react-qr-code:
-        specifier: ^2.0.15
+        specifier: ^2.0.18
         version: 2.0.18(react@19.2.4)
       recharts:
         specifier: ^3.8.0
         version: 3.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@16.13.1)(react@19.2.4)(redux@5.0.1)
       schema-dts:
-        specifier: ^1.1.2
+        specifier: ^1.1.5
         version: 1.1.5
       stripe:
-        specifier: ^17.5.0
+        specifier: ^17.7.0
         version: 17.7.0
       tailwind-merge:
-        specifier: ^3.0.1
+        specifier: ^3.5.0
         version: 3.5.0
       tailwindcss:
-        specifier: ^4.0.0
+        specifier: ^4.2.1
         version: 4.2.1
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.2.1)
       ts-pattern:
-        specifier: ^5.6.0
+        specifier: ^5.9.0
         version: 5.9.0
       zod:
-        specifier: ^3.25.0
+        specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
       '@babel/preset-react':
@@ -211,16 +211,16 @@ importers:
         specifier: ^1.4.21
         version: 1.4.21(@better-fetch/fetch@1.1.21)(@electric-sql/pglite@0.3.15)(@libsql/client@0.14.0)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-call@1.3.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.11)(mongodb@7.1.0)(mysql2@3.15.3)(nanostores@1.1.1)(next@15.1.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(postgres@3.4.7)(prisma@7.5.0(@types/react@19.2.14)(better-sqlite3@12.6.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@eslint/js':
-        specifier: ^9.19.0
+        specifier: ^9.39.4
         version: 9.39.4
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
       '@tailwindcss/postcss':
-        specifier: ^4.0.0
+        specifier: ^4.2.1
         version: 4.2.1
       '@tailwindcss/vite':
-        specifier: ^4.0.0
+        specifier: ^4.2.1
         version: 4.2.1(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@total-typescript/ts-reset':
         specifier: ^0.6.1
@@ -241,19 +241,19 @@ importers:
         specifier: ^0.0.33
         version: 0.0.33
       '@types/lodash':
-        specifier: ^4.17.13
+        specifier: ^4.17.24
         version: 4.17.24
       '@types/react':
-        specifier: ^19.0.2
+        specifier: ^19.2.14
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.0.2
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/parser':
-        specifier: ^8.22.0
+        specifier: ^8.57.0
         version: 8.57.0(eslint@8.57.1)(typescript@5.9.3)
       autoprefixer:
-        specifier: ^10.4.20
+        specifier: ^10.4.27
         version: 10.4.27(postcss@8.5.8)
       better-sqlite3:
         specifier: ^12.6.2
@@ -262,13 +262,13 @@ importers:
         specifier: 4.0.0-beta.3
         version: 4.0.0-beta.3(chokidar@5.0.0)(dotenv@17.3.1)(giget@2.0.0)(jiti@2.6.1)
       cf-content-types-generator:
-        specifier: ^2.15.5
+        specifier: ^2.16.1
         version: 2.16.1
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
       contentful-merge:
-        specifier: ^2.6.5
+        specifier: ^2.6.17
         version: 2.6.17(typescript@5.9.3)
       dotenv:
         specifier: ^17.3.1
@@ -277,7 +277,7 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
       dpdm:
-        specifier: ^3.14.0
+        specifier: ^3.15.1
         version: 3.15.1
       eslint:
         specifier: ^8.57.1
@@ -286,10 +286,10 @@ importers:
         specifier: ^17.1.0
         version: 17.1.0(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint-plugin-n@16.6.2(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-astro:
-        specifier: ^1.3.1
+        specifier: ^1.6.0
         version: 1.6.0(eslint@8.57.1)
       eslint-plugin-import:
-        specifier: ^2.31.0
+        specifier: ^2.32.0
         version: 2.32.0(@typescript-eslint/parser@8.57.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
@@ -301,7 +301,7 @@ importers:
         specifier: ^6.6.0
         version: 6.6.0(eslint@8.57.1)
       eslint-plugin-react-hooks:
-        specifier: ^5.1.0
+        specifier: ^5.2.0
         version: 5.2.0(eslint@8.57.1)
       json-patch:
         specifier: ^0.7.0
@@ -310,43 +310,43 @@ importers:
         specifier: ^0.20.0
         version: 0.20.0(@libsql/kysely-libsql@0.4.1(kysely@0.28.11))(better-sqlite3@12.6.2)(kysely@0.28.11)(mysql2@3.15.3)(pg@8.20.0)(typescript@5.9.3)
       prettier:
-        specifier: ^3.4.2
+        specifier: ^3.8.1
         version: 3.8.1
       prettier-plugin-astro:
         specifier: ^0.14.1
         version: 0.14.1
       prettier-plugin-organize-imports:
-        specifier: ^4.1.0
+        specifier: ^4.3.0
         version: 4.3.0(prettier@3.8.1)(typescript@5.9.3)
       prettier-plugin-tailwindcss:
-        specifier: ^0.6.11
+        specifier: ^0.6.14
         version: 0.6.14(prettier-plugin-astro@0.14.1)(prettier-plugin-organize-imports@4.3.0(prettier@3.8.1)(typescript@5.9.3))(prettier@3.8.1)
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
       react-compiler-runtime:
-        specifier: ^19.0.0-beta-b2e8e9c-20241220
+        specifier: 19.0.0-beta-ebf51a3-20250411
         version: 19.0.0-beta-ebf51a3-20250411(react@19.2.4)
       react-email:
         specifier: 3.0.6
         version: 3.0.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tsx:
-        specifier: ^4.19.2
+        specifier: ^4.21.0
         version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       typescript-eslint:
-        specifier: ^8.22.0
+        specifier: ^8.57.0
         version: 8.57.0(eslint@8.57.1)(typescript@5.9.3)
       vitest:
-        specifier: ^3.0.5
+        specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
       yocto-spinner:
         specifier: ^1.1.0
         version: 1.1.0
       zx:
-        specifier: ^8.3.0
+        specifier: ^8.8.5
         version: 8.8.5
 
 packages:
@@ -4652,8 +4652,8 @@ packages:
   dettle@1.0.5:
     resolution: {integrity: sha512-ZVyjhAJ7sCe1PNXEGveObOH9AC8QvMga3HJIghHawtG7mE4K5pW9nz/vDGAr/U7a3LWgdOzEE7ac9MURnyfaTA==}
 
-  devalue@5.6.3:
-    resolution: {integrity: sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==}
+  devalue@5.6.4:
+    resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -9425,7 +9425,7 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react': 5.1.4(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
-      devalue: 5.6.3
+      devalue: 5.6.4
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       ultrahtml: 1.6.0
@@ -13086,7 +13086,7 @@ snapshots:
       clsx: 2.1.1
       common-ancestor-path: 2.0.0
       cookie: 1.1.1
-      devalue: 5.6.3
+      devalue: 5.6.4
       diff: 8.0.3
       dlv: 1.1.3
       dset: 3.1.4
@@ -14199,7 +14199,7 @@ snapshots:
 
   dettle@1.0.5: {}
 
-  devalue@5.6.3: {}
+  devalue@5.6.4: {}
 
   devlop@1.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Bumps [devalue](https://github.com/sveltejs/devalue) from 5.6.3 to 5.6.4 (security fix)
- Replaces Dependabot PR #282 which conflicted due to npm → pnpm migration
- Fixes: reject `__proto__` keys in malformed payloads, ensure sparse array indices are integers

🤖 Generated with [Claude Code](https://claude.com/claude-code)